### PR TITLE
Update README.md with git submodule commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ supported tooling for doing so.
 
 ### Building
 
-To build all SimKube artifacts, run `make build` and `make skctl` from the root of this repository.
+To build all SimKube artifacts run: 
+- `git submodule init && git submodule update`
+-  `make build` and `make skctl` from the root of this repository.
 
 ### Docker images
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ supported tooling for doing so.
 
 ### Building
 
-To build all SimKube artifacts run: 
-- `git submodule init && git submodule update`
--  `make build` and `make skctl` from the root of this repository.
+To build all SimKube artifacts for the first time run: 
+- `git submodule init && git submodule update` 
+- `make build` and `make skctl` from the root of this repository.
+
+For all subsequent builds of SimKube artifacts, run only `make build` and `make skctl` from the root of this repository.
 
 ### Docker images
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,6 +57,12 @@ needs to be shared between multiple artifacts should go in either `lib/go` or `l
 
 ### Building the artifacts
 
+To build all SimKube artifacts for the first time run: 
+- `git submodule init && git submodule update` 
+- `make build` and `make skctl` from the root of this repository.
+
+For all subsequent builds of SimKube artifacts, run only `make build` and `make skctl` from the root of this repository.
+
 For all the components that run inside a Kubernetes cluster, you can simply run `make build`.  For minor technical
 reasons, the CLI utility (`skctl`) is built separately: `make skctl`.  All build artifacts are placed in the `.build`
 directory at the root of the repository.  If you just want to build a subset of the SimKube artifacts, you can set the


### PR DESCRIPTION
## issue
when following README as is, I ran into a `no such file or directory` error when attempting the build step. 
```
➜  simkube git:(master) make build
Makefile:19: build/base.mk: No such file or directory
make: *** No rule to make target `build/base.mk'.  Stop.
```
## proposed solution
add in `git submodule init` and `git submodule update` to building section in README.md to fix build file missing error when setting up simkube.

## testing
with all prerequisites installed as listed in the README:
- created test directory 
- cloned simkube
- ran `git init submodule`, `git init update`, `make build`, and `make skctl` from the root directory

```
➜  simkube git:(master) git submodule init
Submodule 'build' (https://github.com/acrlabs/build-scripts) registered for path 'build'
➜  simkube git:(master) git submodule update 
Cloning into '/Users/pepper/simbuke2/simkube/build'...
Submodule path 'build': checked out 'eea4f8400c9f1b2b20b9461732e5c174e650f2bd'
➜  simkube git:(master) make build 
...
 Compiling simkube v0.7.0 (/build)
    Finished dev [unoptimized + debuginfo] target(s) in 27.87s
cp /build/.build/debug/sk-tracer /build/.build/.
➜  simkube git:(master) make skctl
CGO_ENABLED=0 go build -trimpath -o /Users/pepper/simbuke2/simkube/.build/skctl ./cli/
```
