### PR TITLE
Update contributing.md with appropriate link to golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ this project agree that they own the copyrights to all contributed material, and
 under the same terms.  This is "inbound=outbound", and is the [GitHub
 default](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license).
 
-!!! warning
-    Due to the uncertain nature of copyright and IP law, this repository does not accept contributions that have been all
-    or partially generated with GitHub Copilot or other LLM-based code generation tools.  Please disable any such tools
-    before authoring changes to this project.
+[!WARNING]
+> Due to the uncertain nature of copyright and IP law, this repository does not accept contributions that have been all
+or partially generated with GitHub Copilot or other LLM-based code generation tools.  Please disable any such tools
+before authoring changes to this project.
 
 ### Contributor's Guide
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ this project agree that they own the copyrights to all contributed material, and
 under the same terms.  This is "inbound=outbound", and is the [GitHub
 default](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license).
 
-[!WARNING]
+> [!WARNING]
 > Due to the uncertain nature of copyright and IP law, this repository does not accept contributions that have been all
 or partially generated with GitHub Copilot or other LLM-based code generation tools.  Please disable any such tools
 before authoring changes to this project.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,7 @@ template: docs.html
 In addition to the project prerequisites, you will need to have the following installed:
 
 - [pre-commit](https://pre-commit.com)
-- [golangci-lint](https://pre-commit.com)
+- [golangci-lint](https://golangci-lint.run/)
 - Nightly version of rustfmt
 
 ### Optional prerequisites


### PR DESCRIPTION
## Two small document changes

1. Updated link in contributing.md to point to golangci-lint's website (it was pointing to the website for the pre-commt project).
2. Updated existing warning in README.md regarding auto-generated code. I simply added a Warning admonition command in Markdown to make this more easily stand out to the reader. 

- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Basic documentation update to fix a link that redirects the reader to a resource not related to the link itself (goes to pre-commit instead of the link's text: golangci-lint)

## Testing done
> - How did you test your changes?
> 1. Committed my code to my fork of the project, then clicked the link and checked that it routed me to golangci-lint.run from GitHub's markdown viewer. 
> 2. Also visually verified that the Warning admonition appears in the README.md file
> - Does this code require any new tests to be written?
> 1. N/A - documentation change only

## Additional info
[Resolves issue #83 ](https://github.com/acrlabs/simkube/issues/83)
