### PR TITLE
skctl run now specifies duration, plus some bug fixes

### DIFF
--- a/cli/args.rs
+++ b/cli/args.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use reqwest::Url;
 use simkube::prelude::*;
-use simkube::time;
+use simkube::time::duration_to_ts;
 
 #[derive(Args)]
 pub struct Delete {
@@ -17,7 +17,7 @@ pub struct Export {
                          to the specified end time, _not_ the current time",
         long,
         default_value = "-30m",
-        value_parser = time::parse,
+        value_parser = duration_to_ts,
         allow_hyphen_values = true,
     )]
     pub start_time: i64,
@@ -26,7 +26,7 @@ pub struct Export {
         long_help = "end time; can be a relative or absolute timestamp",
         long,
         default_value = "now",
-        value_parser = time::parse,
+        value_parser = duration_to_ts,
         allow_hyphen_values = true,
     )]
     pub end_time: i64,
@@ -82,6 +82,9 @@ pub struct Run {
         default_value = "file:///data/trace"
     )]
     pub trace_file: String,
+
+    #[arg(long_help = "duration of the simulation", allow_hyphen_values = true)]
+    pub duration: Option<String>,
 }
 
 #[derive(Args)]
@@ -96,9 +99,6 @@ pub struct Snapshot {
         default_value = "cert-manager,kube-system,local-path-storage,monitoring,simkube"
     )]
     pub excluded_namespaces: Vec<String>,
-
-    #[arg(long_help = "duration of the generated trace file", allow_hyphen_values = true)]
-    pub trace_duration: String,
 
     #[arg(long_help = "location to save exported trace", long, default_value = "trace.out")]
     pub output: String,

--- a/cli/run.rs
+++ b/cli/run.rs
@@ -13,7 +13,8 @@ pub async fn cmd(args: &args::Run) -> EmptyResult {
                 service_account: Some(args.metrics_service_account.clone()),
                 ..Default::default()
             }),
-            trace: args.trace_file.clone(),
+            duration: args.duration.clone(),
+            trace_path: args.trace_file.clone(),
         },
     );
     let client = kube::Client::try_default().await?;

--- a/ctrl/controller.rs
+++ b/ctrl/controller.rs
@@ -199,6 +199,7 @@ pub(super) async fn cleanup(ctx: &SimulationContext, sim: &Simulation) {
         }
     }
     if let Err(e) = prom_api.delete(&ctx.prometheus_name, &Default::default()).await {
+        println!("{e:?}");
         if matches!(e, Api(ErrorResponse { code: 404, .. })) {
             warn!("prometheus object not found; maybe already cleaned up?");
         } else {

--- a/ctrl/objects.rs
+++ b/ctrl/objects.rs
@@ -142,7 +142,7 @@ fn build_driver_args(ctx: &SimulationContext, cert_mount_path: String, trace_mou
         format!("{cert_mount_path}/tls.crt"),
         "--key-path".into(),
         format!("{cert_mount_path}/tls.key"),
-        "--trace-path".into(),
+        "--trace-mount-path".into(),
         trace_mount_path,
         "--virtual-ns-prefix".into(),
         "virtual".into(),

--- a/k8s/poetry.lock
+++ b/k8s/poetry.lock
@@ -44,13 +44,13 @@ ujson = ["ujson (>=5.7.0)"]
 
 [[package]]
 name = "cdk8s"
-version = "2.68.43"
+version = "2.68.44"
 description = "This is the core library of Cloud Development Kit (CDK) for Kubernetes (cdk8s). cdk8s apps synthesize into standard Kubernetes manifests which can be applied to any Kubernetes cluster."
 optional = false
 python-versions = "~=3.8"
 files = [
-    {file = "cdk8s-2.68.43-py3-none-any.whl", hash = "sha256:7a9755f19a11bf118a14ad73307d593402529ed3f798ee76d840dfa824f75ea9"},
-    {file = "cdk8s-2.68.43.tar.gz", hash = "sha256:af76946c9797309e0e0bf4187e99a86465454f32ca87b996be866079dcee30fe"},
+    {file = "cdk8s-2.68.44-py3-none-any.whl", hash = "sha256:2c0417346f28b98c0c03deae4b3610f06e2104018824f6bb469a5668cd6b41b2"},
+    {file = "cdk8s-2.68.44.tar.gz", hash = "sha256:83aa54d0253ea55f354930a6111abe9347cc616d1589b1b7008347a321d12542"},
 ]
 
 [package.dependencies]

--- a/k8s/raw/simkube.io_simulations.yml
+++ b/k8s/raw/simkube.io_simulations.yml
@@ -37,6 +37,9 @@ spec:
             properties:
               driverNamespace:
                 type: string
+              duration:
+                nullable: true
+                type: string
               metricsConfig:
                 nullable: true
                 properties:
@@ -430,11 +433,11 @@ spec:
                 required:
                 - remoteWriteConfigs
                 type: object
-              trace:
+              tracePath:
                 type: string
             required:
             - driverNamespace
-            - trace
+            - tracePath
             type: object
           status:
             nullable: true

--- a/src/api/v1/simulations.rs
+++ b/src/api/v1/simulations.rs
@@ -43,7 +43,8 @@ pub struct SimulationMetricsConfig {
 pub struct SimulationSpec {
     pub driver_namespace: String,
     pub metrics_config: Option<SimulationMetricsConfig>,
-    pub trace: String,
+    pub duration: Option<String>,
+    pub trace_path: String,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]

--- a/src/store/tests/import_export_test.rs
+++ b/src/store/tests/import_export_test.rs
@@ -153,7 +153,7 @@ async fn itest_export() {
     match store.export(start_ts, end_ts, &filter) {
         Ok(data) => {
             // Confirm that the results match what we expect
-            let new_store = TraceStore::import(data).unwrap();
+            let new_store = TraceStore::import(data, &None).unwrap();
             let expected_pods = store.objs_at(end_ts, &filter);
             let actual_pods = new_store.objs_at(end_ts, &filter);
             println!("Expected pods: {:?}", expected_pods);

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,5 +1,12 @@
-use chrono::Utc;
-use parse_datetime::parse_datetime;
+use chrono::{
+    DateTime,
+    Local,
+    Utc,
+};
+use parse_datetime::{
+    parse_datetime,
+    parse_datetime_at_date,
+};
 
 // This trait exists for testing, so that we can provide consistent timestamp values to objects
 // instead of just relying on whatever the current time actually is.
@@ -16,6 +23,11 @@ impl Clockable for UtcClock {
     }
 }
 
-pub fn parse(tstr: &str) -> anyhow::Result<i64> {
+pub fn duration_to_ts(tstr: &str) -> anyhow::Result<i64> {
     Ok(parse_datetime(tstr)?.timestamp())
+}
+
+pub fn duration_to_ts_from(start_ts: i64, tstr: &str) -> anyhow::Result<i64> {
+    let local_time = DateTime::from_timestamp(start_ts, 0).unwrap().with_timezone(&Local);
+    Ok(parse_datetime_at_date(local_time, tstr)?.timestamp())
 }

--- a/src/watch/dyn_obj_watcher.rs
+++ b/src/watch/dyn_obj_watcher.rs
@@ -111,7 +111,9 @@ impl DynObjWatcher {
 
                     // TODO probably don't want to unwrap this
                     // unlike golang, sending is non-blocking
-                    self.ready_tx.send(true).unwrap();
+                    if let Err(e) = self.ready_tx.send(true) {
+                        error!("failed to update ready status: {e:?}")
+                    }
                 }
             },
         };

--- a/src/watch/dyn_obj_watcher.rs
+++ b/src/watch/dyn_obj_watcher.rs
@@ -109,10 +109,9 @@ impl DynObjWatcher {
                 if !self.is_ready {
                     self.is_ready = true;
 
-                    // TODO probably don't want to unwrap this
                     // unlike golang, sending is non-blocking
                     if let Err(e) = self.ready_tx.send(true) {
-                        error!("failed to update ready status: {e:?}")
+                        error!("failed to update dynobjwatcher ready status: {e:?}")
                     }
                 }
             },

--- a/src/watch/pod_watcher.rs
+++ b/src/watch/pod_watcher.rs
@@ -159,9 +159,10 @@ impl PodWatcher {
                 if !self.is_ready {
                     self.is_ready = true;
 
-                    // TODO probably don't want to unwrap this
                     // unlike golang, sending is non-blocking
-                    self.ready_tx.send(true).unwrap();
+                    if let Err(e) = self.ready_tx.send(true) {
+                        error!("failed to update podwatcher ready status: {e:?}")
+                    }
                 }
             },
         };


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
- fix `skctl snapshot` hang (I think)
- fix `sk-tracer` panics if the channel receivers go away
- fix SimulationStatus updates if the Job completes successfully
- update the Simulation spec to add a duration field
- move the duration arg from `skctl snapshot` to `skctl run`, which makes more sense

## Testing done
- make test (with a few new tests)
- manual testing
