### PR TITLE
drop ports when running sim

### DIFF
--- a/driver/runner.rs
+++ b/driver/runner.rs
@@ -67,6 +67,13 @@ pub(super) fn build_virtual_obj(
     )?;
     jsonutils::patch_ext::remove("", "status", &mut vobj.data)?;
 
+    // We remove all container ports from the pod specification just before applying, because it is
+    // _possible_ to create a pod with duplicate container ports, but the apiserver will _reject_ a
+    // patch containing duplicate container ports.  Since pods are mocked out _anyways_ there's no
+    // reason to expose the ports.  We do this here because we still want the ports to be a part of
+    // the podspec when we're computing its hash, i.e., changes to the container ports will still
+    // result in changes to the pod in the trace/simulation
+    jsonutils::patch_ext::remove(&format!("{}/spec/containers/*", pod_spec_template_path), "ports", &mut vobj.data)?;
 
     Ok(vobj)
 }

--- a/src/k8s/pod_ext.rs
+++ b/src/k8s/pod_ext.rs
@@ -39,6 +39,18 @@ impl PodExt for corev1::Pod {
 
         for container in &mut spec.containers {
             container.volume_mounts = Some(filter_volumes!(container.volume_mounts));
+
+            // We strip ports when running the simulation (see note in driver/mutation.rs)
+            // so we also need to strip them when computing the pod hash
+            //
+            // A reasonable question might be, why don't we just strip the ports when we collect
+            // the trace?  My current hypothesis is that saving as much data as possible during
+            // the trace, and then allowing the things processing the trace to do whatever they
+            // need with it is a "better" option, but it results in us having to modify things
+            // in two places at once, which could cause problems in the future.
+            //
+            // TODO is it possible to write a test to check for this somehow?
+            container.ports = None
         }
 
         Ok(spec)


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
It is possible to _create_ a container with two different ports referencing the same port number, but you can't apply a patch to that pod later, even if you're not changing the port definitions.  So in the short term we're just stripping port definitions from the podspec during the simulation.

One could make the argument that we should just strip them from the trace entirely but my working hypothesis is that it's better to leave them in the trace data and let the consumers of the trace figure out what to do with it?  But that requires us to make changes in two different places whenever we touch the pod spec in the simulation -- this impacts the hash we compute for the pod object, so we end up having to make changes in two places at once.

I'd like to maybe have a test for this, but it's not immediately obvious how I'd write such a test so I'm ignoring it for now.

## Testing done
- make test
