### PR TITLE
reference parse_datetime fork, update logging with timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1894,16 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -2035,11 +2051,11 @@ dependencies = [
 
 [[package]]
 name = "parse_datetime"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbf4e25b13841080e018a1e666358adfe5e39b6d353f986ca5091c210b586a1"
+version = "0.6.0"
+source = "git+https://github.com/drmorr0/parse_datetime?rev=748d15b#748d15bb5ed8f7a26f3812c56b4cce1ecdf39599"
 dependencies = [
  "chrono",
+ "nom",
  "regex",
 ]
 
@@ -2356,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ clap = { version = "4.3.21", features = ["cargo", "derive"] }
 futures = "0.3.28"
 json-patch = "1.2.0"
 k8s-openapi = { version = "0.19.0", features = ["v1_27"] }
-parse_datetime = "0.5.0"
+# remove this fork once https://github.com/uutils/parse_datetime/pull/80 is merged and a new version released
+parse_datetime = { git = "https://github.com/drmorr0/parse_datetime", rev = "748d15b" }
 paste = "1.0.14"
 prometheus-http-query = "0.8.2"
 regex = "1.10.2"


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
- Adds some logging around import/export timestamps, references a fork of `parse_datetime` with a fixed duration parsing routing (will want to remove the fork when [the fix](https://github.com/uutils/parse_datetime/pull/80) is merged).

## Testing done
- `make test`
- manual testing by changing my laptop local time
