### PR TITLE
add cleanup delay to driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,9 +827,9 @@ checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "ena"
@@ -2943,6 +2943,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "either",
  "futures",
  "http",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ async-recursion = "1.0.5"
 bytes = "1.5.0"
 chrono = "0.4.26"
 clap = { version = "4.3.21", features = ["cargo", "derive"] }
+either = "1.12.0"
 futures = "0.3.28"
 json-patch = "1.2.0"
 k8s-openapi = { version = "0.19.0", features = ["v1_27"] }

--- a/ctrl/controller.rs
+++ b/ctrl/controller.rs
@@ -39,8 +39,8 @@ use tokio::time::Duration;
 use crate::objects::*;
 use crate::*;
 
-pub(super) const REQUEUE_DURATION: Duration = Duration::from_secs(RETRY_DELAY_SECONDS as u64);
-const REQUEUE_ERROR_DURATION: Duration = Duration::from_secs(ERROR_RETRY_DELAY_SECONDS as u64);
+pub(super) const REQUEUE_DURATION: Duration = Duration::from_secs(RETRY_DELAY_SECONDS);
+const REQUEUE_ERROR_DURATION: Duration = Duration::from_secs(ERROR_RETRY_DELAY_SECONDS);
 pub(super) const JOB_STATUS_CONDITION_COMPLETE: &str = "Complete";
 pub(super) const JOB_STATUS_CONDITION_FAILED: &str = "Failed";
 

--- a/lib/constants.rs
+++ b/lib/constants.rs
@@ -25,5 +25,5 @@ pub const DRIVER_ADMISSION_WEBHOOK_PORT: &str = "8888";
 pub const SK_LEASE_NAME: &str = "sk-lease";
 
 // Timing
-pub const RETRY_DELAY_SECONDS: i64 = 5;
-pub const ERROR_RETRY_DELAY_SECONDS: i64 = 30;
+pub const RETRY_DELAY_SECONDS: u64 = 5;
+pub const ERROR_RETRY_DELAY_SECONDS: u64 = 30;

--- a/lib/k8s/lease.rs
+++ b/lib/k8s/lease.rs
@@ -121,7 +121,7 @@ pub(super) fn compute_remaining_lease_time(
     maybe_renew_time: &Option<metav1::MicroTime>,
     now_ts: i64,
 ) -> i64 {
-    let duration_seconds = maybe_duration_seconds.map_or(0, |secs| secs as i64) + RETRY_DELAY_SECONDS;
+    let duration_seconds = maybe_duration_seconds.map_or(0, |secs| secs as i64) + RETRY_DELAY_SECONDS as i64;
     let renew_time = maybe_renew_time
         .clone()
         .map(|microtime| microtime.0.timestamp())
@@ -129,7 +129,7 @@ pub(super) fn compute_remaining_lease_time(
     let sleep_time = renew_time + duration_seconds - now_ts;
     if sleep_time <= 0 {
         warn!("exceeded the lease time but something hasn't released it; trying again");
-        return RETRY_DELAY_SECONDS;
+        return RETRY_DELAY_SECONDS as i64;
     }
     sleep_time
 }

--- a/lib/k8s/tests/lease_test.rs
+++ b/lib/k8s/tests/lease_test.rs
@@ -187,11 +187,11 @@ async fn test_try_update_lease(test_sim: Simulation, test_sim_root: SimulationRo
 }
 
 #[rstest]
-#[case::no_data(None, None, RETRY_DELAY_SECONDS)]
-#[case::no_renew_time(Some(TEST_LEASE_DURATION), None, TEST_LEASE_DURATION + RETRY_DELAY_SECONDS)]
-#[case::no_duration_seconds(None, Some(13), 13 + RETRY_DELAY_SECONDS - NOW)]
-#[case::valid(Some(TEST_LEASE_DURATION), Some(13), 23 + RETRY_DELAY_SECONDS - NOW)]
-#[case::negative(Some(5), Some(2), RETRY_DELAY_SECONDS)]
+#[case::no_data(None, None, RETRY_DELAY_SECONDS as i64)]
+#[case::no_renew_time(Some(TEST_LEASE_DURATION), None, TEST_LEASE_DURATION + RETRY_DELAY_SECONDS as i64)]
+#[case::no_duration_seconds(None, Some(13), 13 + RETRY_DELAY_SECONDS as i64 - NOW)]
+#[case::valid(Some(TEST_LEASE_DURATION), Some(13), 23 + RETRY_DELAY_SECONDS as i64 - NOW)]
+#[case::negative(Some(5), Some(2), RETRY_DELAY_SECONDS as i64)]
 fn test_compute_remaining_lease_time_no_data(
     #[case] maybe_duration_seconds_64: Option<i64>,
     #[case] maybe_renew_ts: Option<i64>,

--- a/lib/k8s/util.rs
+++ b/lib/k8s/util.rs
@@ -24,6 +24,14 @@ where
         api_version: K::api_version(&()).into(),
         kind: K::kind(&()).into(),
         name: owner.name_any(),
+
+        // if the delete propagation policy is set to foreground, this will block
+        // the owner from being deleted until this object is deleted
+        // (note _both_ must be set, otherwise it doesn't work)
+        //
+        // https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+        block_owner_deletion: Some(true),
+
         // Kubernetes "should" always set this and I'm tired of all the
         // error propogation trying to check for this induces
         uid: owner.uid().unwrap(),


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Waits until the driver has fully cleaned up the old simulation before starting a new one

## Testing done
- `make test` -- new tests covering the cleanup function in the driver
- manual testing

## Additional info
Resolves #113 
