### PR TITLE
fix retry bug and blocking bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test: unit itest
 unit:
 	mkdir -p $(BUILD_DIR)/coverage
 	rm -f $(BUILD_DIR)/coverage/*.profraw
-	$(CARGO_TEST_PREFIX) cargo test --features=testutils $(CARGO_TEST) -- --nocapture --skip itest
+	$(CARGO_TEST_PREFIX) cargo test --features=testutils $(CARGO_TEST) -- --skip itest
 
 .PHONY: itest
 itest:

--- a/ctrl/objects.rs
+++ b/ctrl/objects.rs
@@ -40,7 +40,12 @@ pub(super) fn build_driver_namespace(ctx: &SimulationContext, sim: &Simulation) 
     }
 }
 
-pub(super) fn build_prometheus(name: &str, sim: &Simulation, mc: &SimulationMetricsConfig) -> Prometheus {
+pub(super) fn build_prometheus(
+    name: &str,
+    sim: &Simulation,
+    metaroot: &SimulationRoot,
+    mc: &SimulationMetricsConfig,
+) -> Prometheus {
     // Configure the remote write endpoints; these _can_ be overridden by the user but set up some
     // sane defaults so they don't have to.
     let mut rw_cfgs = mc.remote_write_configs.clone();
@@ -79,7 +84,7 @@ pub(super) fn build_prometheus(name: &str, sim: &Simulation, mc: &SimulationMetr
             .map_or(Default::default(), |name| build_containment_label_selector(APP_KUBERNETES_IO_NAME_KEY, name)),
     );
 
-    let owner = sim;
+    let owner = metaroot;
     Prometheus {
         metadata: build_object_meta(&metrics_ns(sim), name, &sim.name_any(), owner),
         spec: PrometheusSpec {

--- a/driver/runner.rs
+++ b/driver/runner.rs
@@ -112,7 +112,7 @@ pub async fn run_trace(ctx: DriverContext, client: kube::Client) -> EmptyResult 
     let sim_end_ts = ctx.store.end_ts().ok_or(anyhow!("no trace data"))?;
     let sim_duration = sim_end_ts - sim_ts;
 
-    try_update_lease(client.clone(), &ctx.sim, &ctx.ctrl_ns, sim_duration, Box::new(UtcClock)).await?;
+    try_update_lease(client.clone(), &ctx.sim, &ctx.ctrl_ns, sim_duration).await?;
 
     for (evt, maybe_next_ts) in ctx.store.iter() {
         // We're currently assuming that all tracked objects are namespace-scoped,
@@ -165,9 +165,9 @@ pub async fn run_trace(ctx: DriverContext, client: kube::Client) -> EmptyResult 
         }
     }
 
-    let clock = Box::new(UtcClock);
+    let clock = UtcClock::new();
     let timeout = clock.now_ts() + DRIVER_CLEANUP_TIMEOUT_SECONDS;
-    cleanup_trace(&ctx, roots_api, Box::new(UtcClock), timeout).await
+    cleanup_trace(&ctx, roots_api, clock, timeout).await
 }
 
 pub(super) async fn cleanup_trace(

--- a/lib/sim/mod.rs
+++ b/lib/sim/mod.rs
@@ -16,5 +16,9 @@ pub fn metrics_svc_account(sim: &Simulation) -> String {
     }
 }
 
+pub fn is_terminal(sim_state: &SimulationState) -> bool {
+    matches!(sim_state, SimulationState::Finished | SimulationState::Failed)
+}
+
 #[cfg(test)]
 mod tests;

--- a/lib/time.rs
+++ b/lib/time.rs
@@ -18,6 +18,12 @@ pub trait Clockable {
 
 pub struct UtcClock;
 
+impl UtcClock {
+    pub fn new() -> Box<UtcClock> {
+        Box::new(UtcClock)
+    }
+}
+
 impl Clockable for UtcClock {
     fn now(&self) -> DateTime<Utc> {
         Utc::now()

--- a/lib/watch/dyn_obj_watcher.rs
+++ b/lib/watch/dyn_obj_watcher.rs
@@ -69,7 +69,7 @@ impl DynObjWatcher {
 
         Ok((
             DynObjWatcher {
-                clock: Box::new(UtcClock),
+                clock: UtcClock::new(),
                 obj_stream: select_all(apis),
                 store,
 

--- a/lib/watch/pod_watcher.rs
+++ b/lib/watch/pod_watcher.rs
@@ -83,7 +83,7 @@ impl PodWatcher {
                 owners_cache: OwnersCache::new(apiset),
                 store,
 
-                clock: Box::new(UtcClock),
+                clock: UtcClock::new(),
                 is_ready: false,
                 ready_tx: tx,
             },


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
- Fix the "retry" bug -- if the simulation PostStop hooks failed for whatever reason (e.g., if they're trying to clean up and the thing they're cleaning up is already gone), the simulation would get into an endless retry loop.  We move the PostStop hooks logic into `cleanup_simulation` and move the PreStart hooks logic into `setup_simulation` for parallelity, which is totally a word.
- If multiple sims were scheduled simultaneously, it never _actually_ returned `Blocked` for the simulation state.  We now check for (and try to claim) the lease in `fetch_driver_status` instead of `setup_simulation` to fix this bug.

## Testing done
- Manual testing
- new tests added
