### PR TITLE
Fix: specify duration as a named argument in skctl run documentation.

### DIFF
--- a/docs/intro/running.md
+++ b/docs/intro/running.md
@@ -84,7 +84,7 @@ simkube-worker          Ready    <none>          12m   v1.27.3
 ## Step 3: Run your simulation!
 
 ```
-> skctl run my-first-simulation --trace-path s3://your-simkube-bucket/path/to/trace +5m
+> skctl run my-first-simulation --trace-path s3://your-simkube-bucket/path/to/trace --duration +5m
 running simulation my-first-simulation
 ```
 


### PR DESCRIPTION
This is what appears in the [documentation](https://appliedcomputing.io/simkube/docs/intro/running/#step-3-run-your-simulation):
```
> skctl run my-first-simulation --trace-path s3://your-simkube-bucket/path/to/trace +5m
```

Reproducing as faithfully as I can with local storage, preserving the trace-path to preserve duration argument position:
```
> skctl run my-first-simulation --trace-path file:///data/trace +5m
error: unexpected argument '+5m' found
```

Duration is a named argument (see sk-cli/src/run.rs:27) and clap doesn't to my knowledge accept named arguments as positional without weird builder hacks, but the repo uses clap derive, so I think this is an error in the documentation.

This PR changes the documentation to explicitly name the duration argument.

- [X] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this projects policies.
