### PR TITLE
remove custom object store code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -872,12 +872,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast"
@@ -1262,12 +1256,6 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1660,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2134,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbebfd32c213ba1907fa7a9c9138015a8de2b43e30c5aa45b18f7deb46786ad6"
+checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2145,7 +2133,7 @@ dependencies = [
  "futures",
  "humantime",
  "hyper 1.3.1",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -2468,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
  "serde",
@@ -3334,6 +3322,7 @@ dependencies = [
  "httpmock",
  "k8s-openapi",
  "kube",
+ "object_store",
  "reqwest 0.11.27",
  "rstest",
  "schemars",
@@ -3468,24 +3457,23 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
 dependencies = [
- "doc-comment",
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ either = "1.12.0"
 futures = "0.3.28"
 json-patch = "1.2.0"
 k8s-openapi = { version = "0.19.0", features = ["v1_27"] }
-object_store = { version = "0.10.1", features = ["aws", "gcp", "azure", "http"] }
+object_store = { version = "0.11.0", features = ["aws", "gcp", "azure", "http"] }
 # remove this fork once https://github.com/uutils/parse_datetime/pull/80 is merged and a new version released
 parse_datetime = { git = "https://github.com/drmorr0/parse_datetime", rev = "748d15b" }
 paste = "1.0.14"

--- a/sk-core/src/external_storage.rs
+++ b/sk-core/src/external_storage.rs
@@ -1,14 +1,3 @@
-use async_trait::async_trait;
-use bytes::Bytes;
-use object_store::path::Path;
-use object_store::{
-    DynObjectStore,
-    PutPayload,
-};
-use reqwest::Url;
-
-use crate::errors::*;
-
 /// We use the [object_store](https://docs.rs/object_store/latest/object_store/index.html) crate to
 /// enable reading/writing from the three major cloud providers (AWS, Azure, GCP), as well as
 /// to/from a local filesystem or an in-memory store.  Supposedly HTTP with WebDAV is supported as
@@ -33,61 +22,19 @@ use crate::errors::*;
 /// Set the `GOOGLE_SERVICE_ACCOUNT` environment variable to the path for your service account JSON
 /// file (if you're running inside a container, you'll need that file injected as well).  Pass in a
 /// URL like `gs://bucket/path/to/resource`.
-
-// This code is copy-pasta'ed from the object_store library because it is currently private
-// in that library.  This code can all be deleted if/once https://github.com/apache/arrow-rs/pull/5912
-// is merged.
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ObjectStoreScheme {
-    Local,
-    Memory,
-    AmazonS3,
-    GoogleCloudStorage,
-    MicrosoftAzure,
-    Http,
-}
-
-impl ObjectStoreScheme {
-    pub fn parse(url: &Url) -> anyhow::Result<(Self, Path)> {
-        let strip_bucket = || Some(url.path().strip_prefix('/')?.split_once('/')?.1);
-
-        let (scheme, path) = match (url.scheme(), url.host_str()) {
-            ("file", None) => (Self::Local, url.path()),
-            ("memory", None) => (Self::Memory, url.path()),
-            ("s3" | "s3a", Some(_)) => (Self::AmazonS3, url.path()),
-            ("gs", Some(_)) => (Self::GoogleCloudStorage, url.path()),
-            ("az" | "adl" | "azure" | "abfs" | "abfss", Some(_)) => (Self::MicrosoftAzure, url.path()),
-            ("http", Some(_)) => (Self::Http, url.path()),
-            ("https", Some(host)) => {
-                if host.ends_with("dfs.core.windows.net")
-                    || host.ends_with("blob.core.windows.net")
-                    || host.ends_with("dfs.fabric.microsoft.com")
-                    || host.ends_with("blob.fabric.microsoft.com")
-                {
-                    (Self::MicrosoftAzure, url.path())
-                } else if host.ends_with("amazonaws.com") {
-                    match host.starts_with("s3") {
-                        true => (Self::AmazonS3, strip_bucket().unwrap_or_default()),
-                        false => (Self::AmazonS3, url.path()),
-                    }
-                } else if host.ends_with("r2.cloudflarestorage.com") {
-                    (Self::AmazonS3, strip_bucket().unwrap_or_default())
-                } else {
-                    (Self::Http, url.path())
-                }
-            },
-            _ => bail!("unrecognized url: {url}"),
-        };
-
-        Ok((scheme, Path::from_url_path(path)?))
-    }
-}
-
-// End copy-pasta'ed code
-
+use async_trait::async_trait;
+use bytes::Bytes;
 #[cfg(feature = "testutils")]
 use mockall::automock;
+use object_store::path::Path;
+use object_store::{
+    DynObjectStore,
+    ObjectStoreScheme,
+    PutPayload,
+};
+use reqwest::Url;
+
+use crate::errors::*;
 
 #[cfg_attr(feature = "testutils", automock)]
 #[async_trait]
@@ -125,6 +72,7 @@ impl SkObjectStore {
                     .build()?,
             ),
             ObjectStoreScheme::Http => Box::new(object_store::http::HttpBuilder::new().with_url(path_str).build()?),
+            _ => unimplemented!(),
         };
 
         Ok(SkObjectStore { scheme, store, path })

--- a/sk-ctrl/Cargo.toml
+++ b/sk-ctrl/Cargo.toml
@@ -19,6 +19,7 @@ either = { workspace = true }
 futures = { workspace = true }
 kube = { workspace = true }
 k8s-openapi = { workspace = true }
+object_store = { workspace = true }
 reqwest = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/sk-ctrl/src/objects.rs
+++ b/sk-ctrl/src/objects.rs
@@ -6,6 +6,7 @@ use k8s_openapi::api::admissionregistration::v1 as admissionv1;
 use k8s_openapi::api::batch::v1 as batchv1;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::ResourceExt;
+use object_store::ObjectStoreScheme;
 use reqwest::Url;
 use sk_api::prometheus::{
     Prometheus,
@@ -14,7 +15,6 @@ use sk_api::prometheus::{
     PrometheusSpec,
 };
 use sk_api::v1::SimulationMetricsConfig;
-use sk_core::external_storage::ObjectStoreScheme;
 use sk_core::k8s::{
     build_containment_label_selector,
     build_global_object_meta,

--- a/sk-tracer/src/main.rs
+++ b/sk-tracer/src/main.rs
@@ -9,10 +9,10 @@ use std::sync::{
 use bytes::Bytes;
 use clap::Parser;
 use kube::Client;
+use object_store::ObjectStoreScheme;
 use rocket::serde::json::Json;
 use sk_api::v1::ExportRequest;
 use sk_core::external_storage::{
-    ObjectStoreScheme,
     ObjectStoreWrapper,
     SkObjectStore,
 };

--- a/sk-tracer/src/tests/tracer_test.rs
+++ b/sk-tracer/src/tests/tracer_test.rs
@@ -3,9 +3,9 @@ use std::sync::{
     Mutex,
 };
 
+use object_store::ObjectStoreScheme;
 use sk_core::external_storage::{
     MockObjectStoreWrapper,
-    ObjectStoreScheme,
     SkObjectStore,
 };
 


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
object_store made the ObjectStoreScheme enum public so we don't have to roll our own any more

## Testing done
- make test
- manual testing
