### PR TITLE
handle local paths without file:///

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,6 +3526,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ documentation = "https://appliedcomputing.io/simkube/"
 license-file = "LICENSE"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.79"
 
 [profile.dev.package."*"]
 debug = false

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ APP_VERSION=$(shell $(APP_VERSION_CMD))
 include build/base.mk
 include build/k8s.mk
 
-RUST_BUILD_IMAGE ?= rust:buster
+RUST_BUILD_IMAGE ?= rust:1.79-bullseye
 
 main:
 	docker run $(DOCKER_ARGS) -u `id -u`:`id -g` -w /build -v `pwd`:/build:rw -v $(BUILD_DIR):/build/.build:rw $(RUST_BUILD_IMAGE) make build-docker

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -11,7 +11,7 @@ This guide will walk you through installing the various SimKube components
 
 The following prereqs are required for all components:
 
-- [Rust (including Cargo)](https://www.rust-lang.org/learn/get-started) >= 1.71
+- [Rust (including Cargo)](https://www.rust-lang.org/learn/get-started) >= 1.79
 - [Docker](https://docs.docker.com/get-started/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) >= 1.27
 - a Kubernetes cluster running at least v1.27

--- a/images/Dockerfile.sk-ctrl
+++ b/images/Dockerfile.sk-ctrl
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG K8S_VERSION=v1.29.5
 

--- a/images/Dockerfile.sk-driver
+++ b/images/Dockerfile.sk-driver
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG K8S_VERSION=v1.29.5
 

--- a/images/Dockerfile.sk-tracer
+++ b/images/Dockerfile.sk-tracer
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/sk-core/Cargo.toml
+++ b/sk-core/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+url = { workspace = true }
 
 # testutils dependencies
 http = { workspace = true, optional = true }


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Local path resolution in the driver and skctl no longer requires the `file:///` prefix

## Testing done
- Manual testing
- new tests added
