### PR TITLE
fix: print object kind in tracer log

### DIFF
--- a/sk-store/src/trace_store.rs
+++ b/sk-store/src/trace_store.rs
@@ -168,7 +168,15 @@ impl TraceStore {
     }
 
     fn append_event(&mut self, ts: i64, obj: &DynamicObject, action: TraceAction) {
-        info!("{} - {:?} @ {}", obj.namespaced_name(), action, ts);
+        info!(
+            "{:?} @ {ts}: {} {}",
+            action,
+            obj.types
+                .clone()
+                .map(|tm| format!("{}.{}", tm.api_version, tm.kind))
+                .unwrap_or("<unknown type>".into()),
+            obj.namespaced_name(),
+        );
 
         let obj = obj.clone();
         match self.events.back_mut() {


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Update the tracer log lines to include the Kind of the object that it's tracking

## Testing done
- manual testing
