### PR TITLE
ci: cancel old versions of verify workflow

### DIFF
--- a/.github/workflows/k8s_plan.yml
+++ b/.github/workflows/k8s_plan.yml
@@ -6,6 +6,10 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - 'k8s/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   plan:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,10 @@ on:   # yamllint disable-line rule:truthy
       - "master"
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: 0
   SCCACHE_GHA_ENABLED: "true"


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Cancel old versions of the "verify/k8s_plane" workflows when updates to the PR are pushed
