### PR TITLE
feat!: update to versioned exported trace format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,6 +3634,7 @@ dependencies = [
  "serde_yaml",
  "sk-api",
  "sk-core",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,6 +3544,7 @@ dependencies = [
  "httpmock",
  "k8s-openapi",
  "kube",
+ "lazy_static",
  "mockall",
  "object_store",
  "parse_datetime_fork",

--- a/sk-cli/src/crd.rs
+++ b/sk-cli/src/crd.rs
@@ -1,4 +1,3 @@
-use kube::CustomResourceExt;
 use sk_core::prelude::*;
 
 pub fn cmd() -> EmptyResult {

--- a/sk-cli/src/validation/tests/mod.rs
+++ b/sk-cli/src/validation/tests/mod.rs
@@ -4,7 +4,7 @@ mod validation_store_test;
 use std::collections::BTreeMap;
 
 use rstest::*;
-use sk_core::k8s::testutils::test_deployment;
+use sk_core::prelude::*;
 use sk_store::TraceEvent;
 
 use super::annotated_trace::AnnotatedTraceEvent;

--- a/sk-cli/src/validation/tests/status_field_populated_test.rs
+++ b/sk-cli/src/validation/tests/status_field_populated_test.rs
@@ -1,7 +1,6 @@
 use assertables::*;
 use kube::api::DynamicObject;
 use serde_json::json;
-use sk_core::k8s::testutils::test_deployment;
 use sk_store::TraceEvent;
 
 use super::*;

--- a/sk-cli/src/xray/view/helpers.rs
+++ b/sk-cli/src/xray/view/helpers.rs
@@ -2,7 +2,7 @@ use chrono::TimeDelta;
 use kube::api::DynamicObject;
 use lazy_static::lazy_static;
 use ratatui::prelude::*;
-use sk_core::k8s::KubeResourceExt;
+use sk_core::prelude::*;
 
 use crate::validation::{
     AnnotatedTraceEvent,

--- a/sk-core/Cargo.toml
+++ b/sk-core/Cargo.toml
@@ -9,7 +9,7 @@ readme.workspace = true
 edition.workspace = true
 
 [features]
-testutils = ["dep:http", "dep:httpmock", "dep:mockall", "dep:rstest"]
+testutils = ["dep:http", "dep:httpmock", "dep:lazy_static", "dep:mockall", "dep:rstest"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -37,6 +37,7 @@ url = { workspace = true }
 # testutils dependencies
 http = { workspace = true, optional = true }
 httpmock = { workspace = true,  optional = true }
+lazy_static = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 rstest = { workspace = true, optional = true }
 

--- a/sk-core/src/constants.rs
+++ b/sk-core/src/constants.rs
@@ -30,7 +30,10 @@ pub const ERROR_RETRY_DELAY_SECONDS: u64 = 30;
 
 #[cfg(feature = "testutils")]
 mod test_constants {
-    pub const EMPTY_OBJ_HASH: u64 = 15130871412783076140;
+    use lazy_static::lazy_static;
+
+    use crate::k8s::GVK;
+
     pub const EMPTY_POD_SPEC_HASH: u64 = 17506812802394981455;
     pub const TEST_DEPLOYMENT: &str = "the-deployment";
     pub const TEST_NAMESPACE: &str = "test-namespace";
@@ -40,6 +43,11 @@ mod test_constants {
     pub const TEST_DRIVER_ROOT_NAME: &str = "sk-test-driver-12345-root";
     pub const TEST_VIRT_NS_PREFIX: &str = "virt-test";
     pub const TEST_CTRL_NAMESPACE: &str = "ctrl-ns";
+
+    lazy_static! {
+        pub static ref DEPL_GVK: GVK = GVK::new("apps", "v1", "Deployment");
+        pub static ref DS_GVK: GVK = GVK::new("apps", "v1", "DaemonSet");
+    }
 }
 
 #[cfg(feature = "testutils")]

--- a/sk-core/src/hooks.rs
+++ b/sk-core/src/hooks.rs
@@ -9,6 +9,7 @@ use tokio::io::{
     BufWriter,
 };
 use tokio::process::Command;
+use tracing::*;
 
 use crate::prelude::*;
 
@@ -70,7 +71,6 @@ mod test {
     use tracing_test::*;
 
     use super::*;
-    use crate::k8s::testutils::test_sim;
 
     #[rstest]
     #[traced_test]

--- a/sk-core/src/k8s/container_state.rs
+++ b/sk-core/src/k8s/container_state.rs
@@ -1,3 +1,5 @@
+use tracing::*;
+
 use super::*;
 use crate::prelude::*;
 

--- a/sk-core/src/k8s/lease.rs
+++ b/sk-core/src/k8s/lease.rs
@@ -6,8 +6,8 @@ use clockabilly::{
 };
 use k8s_openapi::api::coordination::v1 as coordinationv1;
 use kube::api::Patch;
-use kube::ResourceExt;
 use serde_json::json;
+use tracing::*;
 
 use crate::k8s::{
     build_object_meta,

--- a/sk-core/src/k8s/owners.rs
+++ b/sk-core/src/k8s/owners.rs
@@ -6,10 +6,7 @@ use kube::discovery::{
     ApiCapabilities,
     Scope,
 };
-use kube::{
-    Resource,
-    ResourceExt,
-};
+use kube::Resource;
 use tracing::*;
 
 use super::*;

--- a/sk-core/src/k8s/pod_lifecycle.rs
+++ b/sk-core/src/k8s/pod_lifecycle.rs
@@ -6,7 +6,7 @@ use std::cmp::{
 };
 
 use clockabilly::Clockable;
-use kube::ResourceExt;
+use tracing::*;
 
 use super::*;
 use crate::prelude::*;

--- a/sk-core/src/k8s/sim.rs
+++ b/sk-core/src/k8s/sim.rs
@@ -1,4 +1,3 @@
-use kube::ResourceExt;
 use sk_api::v1::{
     Simulation,
     SimulationMetricsConfig,

--- a/sk-core/src/k8s/tests/mod.rs
+++ b/sk-core/src/k8s/tests/mod.rs
@@ -8,5 +8,4 @@ use rstest::*;
 use tracing_test::traced_test;
 
 use super::*;
-use crate::k8s::testutils::*;
 use crate::macros::*;

--- a/sk-core/src/k8s/tests/owners_test.rs
+++ b/sk-core/src/k8s/tests/owners_test.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use kube::ResourceExt;
 use serde_json::json;
 
 use super::*;

--- a/sk-core/src/k8s/testutils/objs.rs
+++ b/sk-core/src/k8s/testutils/objs.rs
@@ -1,17 +1,24 @@
-use kube::api::{
-    DynamicObject,
-    GroupVersionKind,
-};
+use kube::api::DynamicObject;
 use kube::discovery::ApiResource;
 use rstest::*;
+use serde_json::json;
 
 use crate::prelude::*;
 
+// If the fixture objects below change, these hash values will need to be updated
+pub const TEST_DEPL_HASH: u64 = 3664028200602729212;
+pub const TEST_DS_HASH: u64 = 16161139027557399432;
+
 #[fixture]
 pub fn test_deployment(#[default(TEST_DEPLOYMENT)] name: &str) -> DynamicObject {
-    DynamicObject::new(
-        &name,
-        &ApiResource::from_gvk(&GroupVersionKind::gvk("core".into(), "v1".into(), "deployment".into())),
-    )
-    .within(TEST_NAMESPACE)
+    DynamicObject::new(&name, &ApiResource::from_gvk(&DEPL_GVK))
+        .within(TEST_NAMESPACE)
+        .data(json!({"spec": {"replicas": 42}}))
+}
+
+#[fixture]
+pub fn test_daemonset(#[default(TEST_DEPLOYMENT)] name: &str) -> DynamicObject {
+    DynamicObject::new(&name, &ApiResource::from_gvk(&DS_GVK))
+        .within(TEST_NAMESPACE)
+        .data(json!({"spec": {"updateStrategy": {"type": "onDelete"}}}))
 }

--- a/sk-core/src/k8s/util.rs
+++ b/sk-core/src/k8s/util.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use kube::api::{
     DynamicObject,
     Resource,
-    ResourceExt,
     TypeMeta,
 };
 use serde_json as json;
@@ -39,7 +38,7 @@ where
     });
 }
 
-pub fn build_deletable(ns_name: &str) -> DynamicObject {
+pub fn build_deletable(gvk: &GVK, ns_name: &str) -> DynamicObject {
     let (ns, name) = split_namespaced_name(ns_name);
     DynamicObject {
         metadata: metav1::ObjectMeta {
@@ -47,7 +46,7 @@ pub fn build_deletable(ns_name: &str) -> DynamicObject {
             name: Some(name),
             ..Default::default()
         },
-        types: None,
+        types: Some(gvk.into_type_meta()),
         data: json::Value::Null,
     }
 }

--- a/sk-core/src/k8s/util.rs
+++ b/sk-core/src/k8s/util.rs
@@ -76,6 +76,11 @@ where
     build_object_meta_helper(Some(namespace.into()), name, sim_name, owner)
 }
 
+pub fn format_gvk_name(gvk: &GVK, ns_name: &str) -> String {
+    format!("{gvk}:{ns_name}")
+}
+
+
 pub fn sanitize_obj(obj: &mut DynamicObject, api_version: &str, kind: &str) {
     obj.metadata.creation_timestamp = None;
     obj.metadata.deletion_timestamp = None;

--- a/sk-core/src/lib.rs
+++ b/sk-core/src/lib.rs
@@ -11,12 +11,18 @@ pub mod time;
 pub mod prelude {
     pub use k8s_openapi::api::core::v1 as corev1;
     pub use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
+    pub use kube::{
+        CustomResourceExt,
+        ResourceExt,
+    };
     pub use sk_api::v1::{
         Simulation,
         SimulationRoot,
     };
-    pub use tracing::*;
 
     pub use crate::constants::*;
     pub use crate::errors::EmptyResult;
+    #[cfg(feature = "testutils")]
+    pub use crate::k8s::testutils::*;
+    pub use crate::k8s::KubeResourceExt;
 }

--- a/sk-ctrl/src/cert_manager.rs
+++ b/sk-ctrl/src/cert_manager.rs
@@ -10,6 +10,7 @@ use serde::{
 use sk_core::k8s::build_object_meta;
 use sk_core::macros::*;
 use sk_core::prelude::*;
+use tracing::*;
 
 use crate::context::SimulationContext;
 

--- a/sk-ctrl/src/context.rs
+++ b/sk-ctrl/src/context.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use kube::ResourceExt;
 use sk_api::v1::Simulation;
+use sk_core::prelude::*;
 
 use crate::Options;
 

--- a/sk-ctrl/src/controller.rs
+++ b/sk-ctrl/src/controller.rs
@@ -18,7 +18,6 @@ use kube::api::{
     Patch,
 };
 use kube::runtime::controller::Action;
-use kube::ResourceExt;
 use serde_json::json;
 use sk_api::prometheus::*;
 use sk_api::v1::{
@@ -34,13 +33,13 @@ use sk_core::k8s::{
     is_terminal,
     metrics_ns,
     try_claim_lease,
-    KubeResourceExt,
     LeaseState,
 };
 use sk_core::prelude::*;
 use tokio::runtime::Handle;
 use tokio::task::block_in_place;
 use tokio::time::Duration;
+use tracing::*;
 
 use crate::cert_manager;
 use crate::context::SimulationContext;

--- a/sk-ctrl/src/main.rs
+++ b/sk-ctrl/src/main.rs
@@ -21,6 +21,7 @@ use kube::runtime::{
 };
 use sk_core::logging;
 use sk_core::prelude::*;
+use tracing::*;
 
 use crate::context::SimulationContext;
 use crate::controller::{

--- a/sk-ctrl/src/objects.rs
+++ b/sk-ctrl/src/objects.rs
@@ -5,7 +5,6 @@ use anyhow::anyhow;
 use k8s_openapi::api::admissionregistration::v1 as admissionv1;
 use k8s_openapi::api::batch::v1 as batchv1;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
-use kube::ResourceExt;
 use object_store::ObjectStoreScheme;
 use reqwest::Url;
 use sk_api::prometheus::{

--- a/sk-driver/src/main.rs
+++ b/sk-driver/src/main.rs
@@ -18,7 +18,6 @@ use sk_core::external_storage::{
 };
 use sk_core::k8s::{
     ApiSet,
-    KubeResourceExt,
     OwnersCache,
 };
 use sk_core::prelude::*;
@@ -32,6 +31,7 @@ use sk_store::{
 };
 use tokio::sync::Mutex;
 use tokio::time::sleep;
+use tracing::*;
 
 use crate::mutation::MutationData;
 use crate::runner::run_trace;

--- a/sk-driver/src/mutation.rs
+++ b/sk-driver/src/mutation.rs
@@ -119,16 +119,16 @@ fn add_lifecycle_annotation(
 ) -> EmptyResult {
     if let Some(orig_ns) = pod.annotations().get(ORIG_NAMESPACE_ANNOTATION_KEY) {
         for owner in owners {
-            let gvk = GVK::from_owner_ref(owner)?;
+            let owner_gvk = GVK::from_owner_ref(owner)?;
             let owner_ns_name = format!("{}/{}", orig_ns, owner.name);
-            if !ctx.store.has_obj(&gvk, &owner_ns_name) {
+            if !ctx.store.has_obj(&owner_gvk, &owner_ns_name) {
                 continue;
             }
 
             let hash = jsonutils::hash(&serde_json::to_value(&pod.stable_spec()?)?);
             let seq = mut_data.count(hash);
 
-            let lifecycle = ctx.store.lookup_pod_lifecycle(&owner_ns_name, hash, seq);
+            let lifecycle = ctx.store.lookup_pod_lifecycle(&owner_gvk, &owner_ns_name, hash, seq);
             if let Some(patch) = to_annotation_patch(&lifecycle) {
                 info!("applying lifecycle annotations (hash={hash}, seq={seq})");
                 if pod.metadata.annotations.is_none() {

--- a/sk-driver/src/runner.rs
+++ b/sk-driver/src/runner.rs
@@ -24,7 +24,6 @@ use kube::api::{
     PatchParams,
     PropagationPolicy,
 };
-use kube::ResourceExt;
 use serde_json::json;
 use sk_core::errors::*;
 use sk_core::k8s::{
@@ -38,6 +37,7 @@ use sk_core::k8s::{
 use sk_core::macros::*;
 use sk_core::prelude::*;
 use tokio::time::sleep;
+use tracing::*;
 
 use super::*;
 

--- a/sk-driver/src/tests/data/trace.json
+++ b/sk-driver/src/tests/data/trace.json
@@ -1,12 +1,13 @@
-[
-    {
+{
+    "version": 2,
+    "config": {
         "trackedObjects": {
             "apps/v1.Deployment": {
                 "podSpecTemplatePath": "/spec/template"
             }
         }
     },
-    [
+    "events": [
         {
             "ts": 1709241485,
             "applied_objs": [
@@ -106,8 +107,8 @@
             ]
         }
     ],
-    {
+    "index": {
         "default/nginx-deployment": 2842228259284014139
     },
-    {}
-]
+    "pod_lifecycles": {}
+}

--- a/sk-driver/src/tests/data/trace.json
+++ b/sk-driver/src/tests/data/trace.json
@@ -108,7 +108,9 @@
         }
     ],
     "index": {
-        "default/nginx-deployment": 2842228259284014139
+        "apps/v1.Deployment": {
+            "default/nginx-deployment": 2842228259284014139
+        }
     },
     "pod_lifecycles": {}
 }

--- a/sk-driver/src/tests/mod.rs
+++ b/sk-driver/src/tests/mod.rs
@@ -3,7 +3,7 @@ mod mutation_test;
 mod runner_test;
 
 use rstest::*;
-use sk_core::k8s::testutils::*;
+use sk_core::prelude::*;
 use tracing_test::traced_test;
 
 use super::mutation::*;

--- a/sk-driver/src/tests/mutation_test.rs
+++ b/sk-driver/src/tests/mutation_test.rs
@@ -15,7 +15,6 @@ use kube::core::{
     GroupVersionKind,
     GroupVersionResource,
 };
-use kube::ResourceExt;
 use mockall::predicate;
 use rocket::serde::json::Json;
 use sk_core::k8s::PodLifecycleData;
@@ -134,7 +133,7 @@ async fn test_mutate_pod(mut test_pod: corev1::Pod, mut adm_resp: AdmissionRespo
         .with(predicate::always(), predicate::eq(EMPTY_POD_SPEC_HASH), predicate::eq(0))
         .returning(|_, _, _| PodLifecycleData::Finished(1, 2))
         .once();
-    let _ = store.expect_has_obj().returning(move |o| o == owner_ns_name);
+    let _ = store.expect_has_obj().returning(move |_gvk, o| o == owner_ns_name);
 
     let ctx = ctx(test_pod.clone(), vec![root.clone(), depl.clone()], store);
 

--- a/sk-driver/src/tests/mutation_test.rs
+++ b/sk-driver/src/tests/mutation_test.rs
@@ -130,8 +130,8 @@ async fn test_mutate_pod(mut test_pod: corev1::Pod, mut adm_resp: AdmissionRespo
     let mut store = MockTraceStore::new();
     let _ = store
         .expect_lookup_pod_lifecycle()
-        .with(predicate::always(), predicate::eq(EMPTY_POD_SPEC_HASH), predicate::eq(0))
-        .returning(|_, _, _| PodLifecycleData::Finished(1, 2))
+        .with(predicate::always(), predicate::always(), predicate::eq(EMPTY_POD_SPEC_HASH), predicate::eq(0))
+        .returning(|_, _, _, _| PodLifecycleData::Finished(1, 2))
         .once();
     let _ = store.expect_has_obj().returning(move |_gvk, o| o == owner_ns_name);
 

--- a/sk-store/Cargo.toml
+++ b/sk-store/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sk-api = { workspace = true }
 sk-core = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # testutils dependencies

--- a/sk-store/src/event_list.rs
+++ b/sk-store/src/event_list.rs
@@ -1,0 +1,86 @@
+use std::collections::VecDeque;
+use std::ops::Index;
+
+use kube::api::DynamicObject;
+use sk_core::prelude::*;
+use tracing::*;
+
+use crate::{
+    TraceAction,
+    TraceEvent,
+};
+
+#[derive(Default)]
+pub struct TraceEventList(VecDeque<TraceEvent>);
+
+impl TraceEventList {
+    pub(crate) fn append(&mut self, ts: i64, obj: &DynamicObject, action: TraceAction) {
+        info!(
+            "{:?} @ {ts}: {} {}",
+            action,
+            obj.types
+                .clone()
+                .map(|tm| format!("{}.{}", tm.api_version, tm.kind))
+                .unwrap_or("<unknown type>".into()),
+            obj.namespaced_name(),
+        );
+
+        let obj = obj.clone();
+        match self.0.back_mut() {
+            Some(evt) if evt.ts == ts => match action {
+                TraceAction::ObjectApplied => evt.applied_objs.push(obj),
+                TraceAction::ObjectDeleted => evt.deleted_objs.push(obj),
+            },
+            _ => {
+                let evt = match action {
+                    TraceAction::ObjectApplied => TraceEvent { ts, applied_objs: vec![obj], ..Default::default() },
+                    TraceAction::ObjectDeleted => TraceEvent { ts, deleted_objs: vec![obj], ..Default::default() },
+                };
+                self.0.push_back(evt);
+            },
+        }
+    }
+
+    pub(crate) fn back(&self) -> Option<&TraceEvent> {
+        self.0.back()
+    }
+
+    pub(crate) fn front(&self) -> Option<&TraceEvent> {
+        self.0.front()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl Index<usize> for TraceEventList {
+    type Output = TraceEvent;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        &self.0[i]
+    }
+}
+
+impl From<VecDeque<TraceEvent>> for TraceEventList {
+    fn from(v: VecDeque<TraceEvent>) -> TraceEventList {
+        TraceEventList(v)
+    }
+}
+
+impl From<Vec<TraceEvent>> for TraceEventList {
+    fn from(v: Vec<TraceEvent>) -> TraceEventList {
+        TraceEventList(v.into())
+    }
+}
+
+#[cfg(test)]
+impl FromIterator<TraceEvent> for TraceEventList {
+    fn from_iter<T: IntoIterator<Item = TraceEvent>>(ii: T) -> Self {
+        TraceEventList(ii.into_iter().collect())
+    }
+}

--- a/sk-store/src/filter.rs
+++ b/sk-store/src/filter.rs
@@ -1,6 +1,6 @@
 use kube::api::DynamicObject;
 use sk_api::v1::ExportFilters;
-use sk_core::k8s::KubeResourceExt;
+use sk_core::prelude::*;
 
 use super::TraceEvent;
 

--- a/sk-store/src/index.rs
+++ b/sk-store/src/index.rs
@@ -5,7 +5,10 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use sk_core::k8s::GVK;
+use sk_core::k8s::{
+    format_gvk_name,
+    GVK,
+};
 
 #[derive(Default, Deserialize, Serialize)]
 pub struct TraceIndex {
@@ -25,7 +28,7 @@ impl TraceIndex {
     pub fn flattened_keys(&self) -> Vec<String> {
         self.index
             .iter()
-            .flat_map(|(gvk, gvk_hash)| gvk_hash.keys().map(move |k| format!("{gvk}:{k}")))
+            .flat_map(|(gvk, gvk_hash)| gvk_hash.keys().map(move |ns_name| format_gvk_name(gvk, ns_name)))
             .collect()
     }
 

--- a/sk-store/src/index.rs
+++ b/sk-store/src/index.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::mem::take;
+
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use sk_core::k8s::GVK;
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct TraceIndex {
+    #[serde(flatten)]
+    index: HashMap<GVK, HashMap<String, u64>>,
+}
+
+impl TraceIndex {
+    pub fn new() -> TraceIndex {
+        TraceIndex::default()
+    }
+
+    pub fn contains(&self, gvk: &GVK, ns_name: &str) -> bool {
+        self.index.get(gvk).is_some_and(|gvk_hash| gvk_hash.contains_key(ns_name))
+    }
+
+    pub fn flattened_keys(&self) -> Vec<String> {
+        self.index
+            .iter()
+            .flat_map(|(gvk, gvk_hash)| gvk_hash.keys().map(move |k| format!("{gvk}:{k}")))
+            .collect()
+    }
+
+    pub fn get(&self, gvk: &GVK, ns_name: &str) -> Option<u64> {
+        self.index.get(gvk)?.get(ns_name).cloned()
+    }
+
+    pub fn insert(&mut self, gvk: GVK, ns_name: String, hash: u64) {
+        self.index.entry(gvk).or_default().insert(ns_name, hash);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.index.values().all(|gvk_hash| gvk_hash.is_empty())
+    }
+
+    pub fn len(&self) -> usize {
+        self.index.values().map(|gvk_hash| gvk_hash.len()).sum()
+    }
+
+    pub fn remove(&mut self, gvk: GVK, ns_name: &str) {
+        self.index.entry(gvk).and_modify(|gvk_hash| {
+            gvk_hash.remove(ns_name);
+        });
+    }
+
+    pub fn take_gvk_index(&mut self, gvk: &GVK) -> HashMap<String, u64> {
+        take(self.index.get_mut(gvk).unwrap_or(&mut HashMap::new()))
+    }
+}

--- a/sk-store/src/lib.rs
+++ b/sk-store/src/lib.rs
@@ -1,10 +1,12 @@
 mod config;
+mod event_list;
+mod filter;
+mod index;
 mod pod_owners_map;
-mod trace_filter;
-mod trace_store;
+mod store;
 pub mod watchers;
 
-use std::collections::VecDeque;
+use std::collections::HashMap;
 
 use kube::api::DynamicObject;
 use serde::{
@@ -12,17 +14,20 @@ use serde::{
     Serialize,
 };
 use sk_core::errors::*;
-use sk_core::k8s::PodLifecycleData;
+use sk_core::k8s::{
+    PodLifecycleData,
+    GVK,
+};
 use sk_core::prelude::*;
 
 pub use crate::config::{
     TracerConfig,
     TrackedObjectConfig,
 };
-pub use crate::trace_store::{
-    ExportedTrace,
-    TraceStore,
-};
+pub use crate::event_list::TraceEventList;
+pub use crate::index::TraceIndex;
+use crate::pod_owners_map::PodLifecyclesMap;
+pub use crate::store::TraceStore;
 
 #[derive(Debug)]
 enum TraceAction {
@@ -38,14 +43,23 @@ pub struct TraceEvent {
 }
 
 pub struct TraceIterator<'a> {
-    events: &'a VecDeque<TraceEvent>,
+    events: &'a TraceEventList,
     idx: usize,
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct ExportedTrace {
+    version: u16,
+    config: TracerConfig,
+    events: Vec<TraceEvent>,
+    index: TraceIndex,
+    pod_lifecycles: HashMap<String, PodLifecyclesMap>,
+}
+
 pub trait TraceStorable {
-    fn create_or_update_obj(&mut self, obj: &DynamicObject, ts: i64, maybe_old_hash: Option<u64>);
-    fn delete_obj(&mut self, obj: &DynamicObject, ts: i64);
-    fn update_all_objs(&mut self, objs: &[DynamicObject], ts: i64);
+    fn create_or_update_obj(&mut self, obj: &DynamicObject, ts: i64, maybe_old_hash: Option<u64>) -> EmptyResult;
+    fn delete_obj(&mut self, obj: &DynamicObject, ts: i64) -> EmptyResult;
+    fn update_all_objs_for_gvk(&mut self, gvk: &GVK, objs: &[DynamicObject], ts: i64) -> EmptyResult;
     fn lookup_pod_lifecycle(&self, owner_ns_name: &str, pod_hash: u64, seq: usize) -> PodLifecycleData;
     fn record_pod_lifecycle(
         &mut self,
@@ -55,7 +69,7 @@ pub trait TraceStorable {
         lifecycle_data: &PodLifecycleData,
     ) -> EmptyResult;
     fn config(&self) -> &TracerConfig;
-    fn has_obj(&self, ns_name: &str) -> bool;
+    fn has_obj(&self, gvk: &GVK, ns_name: &str) -> bool;
     fn start_ts(&self) -> Option<i64>;
     fn end_ts(&self) -> Option<i64>;
     fn iter(&self) -> TraceIterator<'_>;
@@ -74,9 +88,9 @@ pub mod mock {
         pub TraceStore {}
 
         impl TraceStorable for TraceStore {
-            fn create_or_update_obj(&mut self, obj: &DynamicObject, ts: i64, maybe_old_hash: Option<u64>);
-            fn delete_obj(&mut self, obj: &DynamicObject, ts: i64);
-            fn update_all_objs(&mut self, objs: &[DynamicObject], ts: i64);
+            fn create_or_update_obj(&mut self, obj: &DynamicObject, ts: i64, maybe_old_hash: Option<u64>) -> EmptyResult;
+            fn delete_obj(&mut self, obj: &DynamicObject, ts: i64) -> EmptyResult;
+            fn update_all_objs_for_gvk(&mut self, gvk: &GVK, objs: &[DynamicObject], ts: i64) -> EmptyResult;
             fn lookup_pod_lifecycle(&self, owner_ns_name: &str, pod_hash: u64, seq: usize) -> PodLifecycleData;
             fn record_pod_lifecycle(
                 &mut self,
@@ -86,7 +100,7 @@ pub mod mock {
                 lifecycle_data: &PodLifecycleData,
             ) -> EmptyResult;
             fn config(&self) -> &TracerConfig;
-            fn has_obj(&self, ns_name: &str) -> bool;
+            fn has_obj(&self, gvk: &GVK, ns_name: &str) -> bool;
             fn start_ts(&self) -> Option<i64>;
             fn end_ts(&self) -> Option<i64>;
             fn iter<'a>(&'a self) -> TraceIterator<'a>;
@@ -95,4 +109,10 @@ pub mod mock {
 }
 
 #[cfg(feature = "testutils")]
-pub use crate::pod_owners_map::PodLifecyclesMap;
+impl ExportedTrace {
+    pub fn prepend_event(&mut self, event: TraceEvent) {
+        let mut tmp = vec![event];
+        tmp.append(&mut self.events);
+        self.events = tmp;
+    }
+}

--- a/sk-store/src/lib.rs
+++ b/sk-store/src/lib.rs
@@ -19,10 +19,11 @@ pub use crate::config::{
     TracerConfig,
     TrackedObjectConfig,
 };
-pub use crate::trace_store::TraceStore;
+pub use crate::trace_store::{
+    ExportedTrace,
+    TraceStore,
+};
 
-#[cfg(test)]
-mod tests;
 #[derive(Debug)]
 enum TraceAction {
     ObjectApplied,
@@ -59,6 +60,9 @@ pub trait TraceStorable {
     fn end_ts(&self) -> Option<i64>;
     fn iter(&self) -> TraceIterator<'_>;
 }
+
+#[cfg(test)]
+mod tests;
 
 #[cfg(feature = "testutils")]
 pub mod mock {

--- a/sk-store/src/lib.rs
+++ b/sk-store/src/lib.rs
@@ -53,14 +53,14 @@ pub struct ExportedTrace {
     config: TracerConfig,
     events: Vec<TraceEvent>,
     index: TraceIndex,
-    pod_lifecycles: HashMap<String, PodLifecyclesMap>,
+    pod_lifecycles: HashMap<(GVK, String), PodLifecyclesMap>,
 }
 
 pub trait TraceStorable {
     fn create_or_update_obj(&mut self, obj: &DynamicObject, ts: i64, maybe_old_hash: Option<u64>) -> EmptyResult;
     fn delete_obj(&mut self, obj: &DynamicObject, ts: i64) -> EmptyResult;
     fn update_all_objs_for_gvk(&mut self, gvk: &GVK, objs: &[DynamicObject], ts: i64) -> EmptyResult;
-    fn lookup_pod_lifecycle(&self, owner_ns_name: &str, pod_hash: u64, seq: usize) -> PodLifecycleData;
+    fn lookup_pod_lifecycle(&self, gvk: &GVK, owner_ns_name: &str, pod_hash: u64, seq: usize) -> PodLifecycleData;
     fn record_pod_lifecycle(
         &mut self,
         ns_name: &str,
@@ -91,7 +91,7 @@ pub mod mock {
             fn create_or_update_obj(&mut self, obj: &DynamicObject, ts: i64, maybe_old_hash: Option<u64>) -> EmptyResult;
             fn delete_obj(&mut self, obj: &DynamicObject, ts: i64) -> EmptyResult;
             fn update_all_objs_for_gvk(&mut self, gvk: &GVK, objs: &[DynamicObject], ts: i64) -> EmptyResult;
-            fn lookup_pod_lifecycle(&self, owner_ns_name: &str, pod_hash: u64, seq: usize) -> PodLifecycleData;
+            fn lookup_pod_lifecycle(&self, owner_gvk: &GVK, owner_ns_name: &str, pod_hash: u64, seq: usize) -> PodLifecycleData;
             fn record_pod_lifecycle(
                 &mut self,
                 ns_name: &str,

--- a/sk-store/src/pod_owners_map.rs
+++ b/sk-store/src/pod_owners_map.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use sk_core::errors::*;
 use sk_core::k8s::PodLifecycleData;
-use sk_core::prelude::*;
+use tracing::*;
 
 // The PodOwnersMap tracks lifecycle data for all pods that are owned by some object that we care
 // about (e.g., if we are tracking Deployments, the owners map will track the lifecycle data for
@@ -121,6 +121,7 @@ impl PodOwnersMap {
 
     // Given an index of "owning objects", get a list of all the pods between a given start and end
     // time that belong to one of those owning objects.
+    #[allow(dead_code)]
     pub(crate) fn filter(
         &self,
         start_ts: i64,

--- a/sk-store/src/pod_owners_map.rs
+++ b/sk-store/src/pod_owners_map.rs
@@ -2,8 +2,14 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use sk_core::errors::*;
-use sk_core::k8s::PodLifecycleData;
+use sk_core::k8s::{
+    format_gvk_name,
+    PodLifecycleData,
+    GVK,
+};
 use tracing::*;
+
+use crate::TraceIndex;
 
 // The PodOwnersMap tracks lifecycle data for all pods that are owned by some object that we care
 // about (e.g., if we are tracking Deployments, the owners map will track the lifecycle data for
@@ -46,14 +52,14 @@ pub type PodLifecyclesMap = HashMap<u64, Vec<PodLifecycleData>>;
 
 #[derive(Default)]
 pub(crate) struct PodOwnersMap {
-    m: HashMap<String, PodLifecyclesMap>,
-    index: HashMap<String, (String, u64, usize)>,
+    m: HashMap<(GVK, String), PodLifecyclesMap>,
+    index: HashMap<String, ((GVK, String), u64, usize)>,
 }
 
 impl PodOwnersMap {
     pub(crate) fn new_from_parts(
-        m: HashMap<String, PodLifecyclesMap>,
-        index: HashMap<String, (String, u64, usize)>,
+        m: HashMap<(GVK, String), PodLifecyclesMap>,
+        index: HashMap<String, ((GVK, String), u64, usize)>,
     ) -> PodOwnersMap {
         PodOwnersMap { m, index }
     }
@@ -64,20 +70,23 @@ impl PodOwnersMap {
 
     pub(crate) fn lifecycle_data_for<'a>(
         &'a self,
+        owner_gvk: &GVK,
         owner_ns_name: &str,
         pod_hash: u64,
     ) -> Option<&'a Vec<PodLifecycleData>> {
-        self.m.get(owner_ns_name)?.get(&pod_hash)
+        self.m.get(&(owner_gvk.clone(), owner_ns_name.into()))?.get(&pod_hash)
     }
 
     pub(crate) fn store_new_pod_lifecycle(
         &mut self,
-        ns_name: &str,
+        pod_ns_name: &str,
+        owner_gvk: &GVK,
         owner_ns_name: &str,
         hash: u64,
         lifecycle_data: &PodLifecycleData,
     ) {
-        let idx = match self.m.entry(owner_ns_name.into()) {
+        let owner_gvk_name = format_gvk_name(owner_gvk, owner_ns_name);
+        let idx = match self.m.entry((owner_gvk.clone(), owner_ns_name.into())) {
             Entry::Vacant(e) => {
                 e.insert([(hash, vec![lifecycle_data.clone()])].into());
                 0
@@ -89,30 +98,33 @@ impl PodOwnersMap {
             },
         };
 
-        info!("inserting pod {ns_name} owned by {owner_ns_name} with hash {hash}: {lifecycle_data:?}");
-        self.index.insert(ns_name.into(), (owner_ns_name.into(), hash, idx));
+        info!("inserting pod {pod_ns_name} owned by {owner_gvk_name} with hash {hash}: {lifecycle_data:?}");
+        self.index
+            .insert(pod_ns_name.into(), ((owner_gvk.clone(), owner_ns_name.into()), hash, idx));
     }
 
-    pub(crate) fn update_pod_lifecycle(&mut self, ns_name: &str, lifecycle_data: &PodLifecycleData) -> EmptyResult {
-        match self.index.get(ns_name) {
-            None => bail!("pod {} not present in index", ns_name),
-            Some((owner_ns_name, hash, sequence_idx)) => {
+    pub(crate) fn update_pod_lifecycle(&mut self, pod_ns_name: &str, lifecycle_data: &PodLifecycleData) -> EmptyResult {
+        match self.index.get(pod_ns_name) {
+            None => bail!("pod {} not present in index", pod_ns_name),
+            Some(((owner_gvk, owner_ns_name), hash, sequence_idx)) => {
                 let owner_entry = self
                     .m
-                    .get_mut(owner_ns_name)
-                    .ok_or(anyhow!("no owner entry for pod {}", ns_name))?;
-                let pods =
-                    owner_entry
-                        .get_mut(hash)
-                        .ok_or(anyhow!("no entry for pod {} matching hash {}", ns_name, hash))?;
+                    .get_mut(&(owner_gvk.clone(), owner_ns_name.into()))
+                    .ok_or(anyhow!("no owner entry for pod {}", pod_ns_name))?;
+                let pods = owner_entry.get_mut(hash).ok_or(anyhow!(
+                    "no entry for pod {} matching hash {}",
+                    pod_ns_name,
+                    hash
+                ))?;
                 let pod_entry = pods.get_mut(*sequence_idx).ok_or(anyhow!(
                     "no sequence index {} for pod {} matching hash {}",
                     sequence_idx,
-                    ns_name,
+                    pod_ns_name,
                     hash
                 ))?;
 
-                info!("updating pod {ns_name} owned by {owner_ns_name} with hash {hash}: {lifecycle_data:?}");
+                let owner_gvk_name = format_gvk_name(owner_gvk, owner_ns_name);
+                info!("updating pod {pod_ns_name} owned by {owner_gvk_name} with hash {hash}: {lifecycle_data:?}");
                 *pod_entry = lifecycle_data.clone();
                 Ok(())
             },
@@ -126,21 +138,24 @@ impl PodOwnersMap {
         &self,
         start_ts: i64,
         end_ts: i64,
-        index: &HashMap<String, u64>,
-    ) -> HashMap<String, PodLifecyclesMap> {
+        index: &TraceIndex,
+    ) -> HashMap<(GVK, String), PodLifecyclesMap> {
         self.m
             .iter()
             // The filtering is a little complicated here; if the owning object isn't in the index,
             // we discard it.  Also, if none of the pods belonging to the owning object land
             // within the given time window, we want to discard it.  Otherwise, we want to filter
             // down the list of pods to the ones that fall between the given time window.
-            .filter_map(|(owner, lifecycles_map)| {
-                if !index.contains_key(owner) {
+            .filter_map(|((owner_gvk, owner_ns_name), lifecycles_map)| {
+                if !index.contains(owner_gvk, owner_ns_name) {
                     return None;
                 }
 
                 // Note the question mark here, doing a bunch of heavy lifting
-                Some((owner.clone(), filter_lifecycles_map(start_ts, end_ts, lifecycles_map)?))
+                Some((
+                    (owner_gvk.clone(), owner_ns_name.clone()),
+                    filter_lifecycles_map(start_ts, end_ts, lifecycles_map)?,
+                ))
             })
             .collect()
     }
@@ -170,7 +185,7 @@ pub(crate) fn filter_lifecycles_map(
 
 #[cfg(test)]
 impl PodOwnersMap {
-    pub(crate) fn pod_owner_meta(&self, ns_name: &str) -> Option<&(String, u64, usize)> {
-        self.index.get(ns_name)
+    pub(crate) fn pod_owner_meta(&self, pod_ns_name: &str) -> Option<&((GVK, String), u64, usize)> {
+        self.index.get(pod_ns_name)
     }
 }

--- a/sk-store/src/tests/pod_owners_map_test.rs
+++ b/sk-store/src/tests/pod_owners_map_test.rs
@@ -17,34 +17,48 @@ fn owners_map() -> PodOwnersMap {
 
 #[rstest]
 fn test_store_new_pod_lifecycle(mut owners_map: PodOwnersMap) {
-    owners_map.store_new_pod_lifecycle("podA", "deployment1", 1234, &PodLifecycleData::Running(5));
-    owners_map.store_new_pod_lifecycle("podB", "deployment1", 1234, &PodLifecycleData::Running(7));
-    owners_map.store_new_pod_lifecycle("podC", "deployment1", 5678, &PodLifecycleData::Running(9));
-    owners_map.store_new_pod_lifecycle("podD", "deployment2", 5678, &PodLifecycleData::Running(13));
+    owners_map.store_new_pod_lifecycle("podA", &DEPL_GVK, "deployment1", 1234, &PodLifecycleData::Running(5));
+    owners_map.store_new_pod_lifecycle("podB", &DEPL_GVK, "deployment1", 1234, &PodLifecycleData::Running(7));
+    owners_map.store_new_pod_lifecycle("podC", &DEPL_GVK, "deployment1", 5678, &PodLifecycleData::Running(9));
+    owners_map.store_new_pod_lifecycle("podD", &DEPL_GVK, "deployment2", 5678, &PodLifecycleData::Running(13));
     assert_eq!(
-        owners_map.lifecycle_data_for("deployment1", 1234).unwrap(),
+        owners_map.lifecycle_data_for(&DEPL_GVK, "deployment1", 1234).unwrap(),
         &vec![PodLifecycleData::Running(5), PodLifecycleData::Running(7)]
     );
-    assert_eq!(owners_map.lifecycle_data_for("deployment1", 5678).unwrap(), &vec![PodLifecycleData::Running(9)]);
-    assert_eq!(owners_map.lifecycle_data_for("deployment2", 5678).unwrap(), &vec![PodLifecycleData::Running(13)]);
+    assert_eq!(
+        owners_map.lifecycle_data_for(&DEPL_GVK, "deployment1", 5678).unwrap(),
+        &vec![PodLifecycleData::Running(9)]
+    );
+    assert_eq!(
+        owners_map.lifecycle_data_for(&DEPL_GVK, "deployment2", 5678).unwrap(),
+        &vec![PodLifecycleData::Running(13)]
+    );
 
-    assert_eq!(*owners_map.pod_owner_meta("podA").unwrap(), ("deployment1".to_string(), 1234, 0));
-    assert_eq!(*owners_map.pod_owner_meta("podB").unwrap(), ("deployment1".to_string(), 1234, 1));
-    assert_eq!(*owners_map.pod_owner_meta("podC").unwrap(), ("deployment1".to_string(), 5678, 0));
-    assert_eq!(*owners_map.pod_owner_meta("podD").unwrap(), ("deployment2".to_string(), 5678, 0));
+    assert_eq!(*owners_map.pod_owner_meta("podA").unwrap(), ((DEPL_GVK.clone(), "deployment1".into()), 1234, 0));
+    assert_eq!(*owners_map.pod_owner_meta("podB").unwrap(), ((DEPL_GVK.clone(), "deployment1".into()), 1234, 1));
+    assert_eq!(*owners_map.pod_owner_meta("podC").unwrap(), ((DEPL_GVK.clone(), "deployment1".into()), 5678, 0));
+    assert_eq!(*owners_map.pod_owner_meta("podD").unwrap(), ((DEPL_GVK.clone(), "deployment2".into()), 5678, 0));
 }
 
 #[rstest]
 fn test_filter_owners_map() {
-    let index = HashMap::from([("test/deployment1".into(), 9876), ("test/deployment2".into(), 5432)]);
+    let mut index = TraceIndex::new();
+    index.insert(DEPL_GVK.clone(), "test/deployment1".into(), 9876);
+    index.insert(DEPL_GVK.clone(), "test/deployment2".into(), 5432);
     let owners_map = PodOwnersMap::new_from_parts(
         HashMap::from([
-            ("test/deployment1".into(), PodLifecyclesMap::from([(1234, vec![PodLifecycleData::Finished(1, 2)])])),
             (
-                "test/deployment2".into(),
+                (DEPL_GVK.clone(), "test/deployment1".into()),
+                PodLifecyclesMap::from([(1234, vec![PodLifecycleData::Finished(1, 2)])]),
+            ),
+            (
+                (DEPL_GVK.clone(), "test/deployment2".into()),
                 PodLifecyclesMap::from([(5678, vec![PodLifecycleData::Running(6), PodLifecycleData::Running(11)])]),
             ),
-            ("test/deployment3".into(), PodLifecyclesMap::from([(9999, vec![PodLifecycleData::Finished(1, 2)])])),
+            (
+                (DEPL_GVK.clone(), "test/deployment3".into()),
+                PodLifecyclesMap::from([(9999, vec![PodLifecycleData::Finished(1, 2)])]),
+            ),
         ]),
         HashMap::new(),
     );
@@ -53,7 +67,7 @@ fn test_filter_owners_map() {
     assert_eq!(
         res,
         HashMap::from([(
-            "test/deployment2".into(),
+            (DEPL_GVK.clone(), "test/deployment2".into()),
             PodLifecyclesMap::from([(5678, vec![PodLifecycleData::Running(6)])]),
         )])
     );

--- a/sk-store/src/tests/trace_store_test.rs
+++ b/sk-store/src/tests/trace_store_test.rs
@@ -2,12 +2,8 @@ use std::collections::HashMap;
 
 use assertables::*;
 use kube::api::DynamicObject;
-use serde_json::json;
 use sk_api::v1::ExportFilters;
-use sk_core::k8s::{
-    KubeResourceExt,
-    GVK,
-};
+use sk_core::k8s::GVK;
 
 use super::*;
 use crate::pod_owners_map::PodOwnersMap;
@@ -16,26 +12,13 @@ use crate::pod_owners_map::PodOwnersMap;
 fn tracer() -> TraceStore {
     TraceStore::new(TracerConfig {
         tracked_objects: HashMap::from([(
-            GVK::new("apps", "v1", "Deployment"),
+            DEPL_GVK.clone(),
             TrackedObjectConfig {
                 track_lifecycle: true,
                 pod_spec_template_path: Some("/spec/template".into()),
             },
         )]),
     })
-}
-
-#[fixture]
-fn test_obj(#[default("obj")] name: &str) -> DynamicObject {
-    DynamicObject {
-        metadata: metav1::ObjectMeta {
-            namespace: Some(TEST_NAMESPACE.into()),
-            name: Some(name.into()),
-            ..Default::default()
-        },
-        types: None,
-        data: json!({"spec": {}}),
-    }
 }
 
 #[fixture]
@@ -56,7 +39,7 @@ fn test_lookup_pod_lifecycle_no_owner(tracer: TraceStore) {
 
 #[rstest]
 fn test_lookup_pod_lifecycle_no_hash(mut tracer: TraceStore) {
-    tracer.index.insert(TEST_DEPLOYMENT.into(), 1234);
+    tracer.index.insert(DEPL_GVK.clone(), TEST_DEPLOYMENT.into(), 1234);
     let res = tracer.lookup_pod_lifecycle(TEST_DEPLOYMENT, EMPTY_POD_SPEC_HASH, 0);
     assert_eq!(res, PodLifecycleData::Empty);
 }
@@ -66,7 +49,7 @@ fn test_lookup_pod_lifecycle(mut tracer: TraceStore) {
     let owner_ns_name = format!("{TEST_NAMESPACE}/{TEST_DEPLOYMENT}");
     let pod_lifecycle = PodLifecycleData::Finished(1, 2);
 
-    tracer.index.insert(owner_ns_name.clone(), 1234);
+    tracer.index.insert(DEPL_GVK.clone(), owner_ns_name.clone(), 1234);
     tracer.pod_owners = PodOwnersMap::new_from_parts(
         HashMap::from([(owner_ns_name.clone(), HashMap::from([(EMPTY_POD_SPEC_HASH, vec![pod_lifecycle.clone()])]))]),
         HashMap::new(),
@@ -82,20 +65,22 @@ fn test_collect_events_filtered(mut tracer: TraceStore) {
         .iter()
         .map(|(name, ts)| TraceEvent {
             ts: *ts,
-            applied_objs: vec![test_obj(name)],
+            applied_objs: vec![test_deployment(name)],
             deleted_objs: vec![],
         })
         .collect();
 
-    let (events, index) = tracer.collect_events(
-        1,
-        10,
-        &ExportFilters {
-            excluded_namespaces: vec![TEST_NAMESPACE.into()],
-            ..Default::default()
-        },
-        false,
-    );
+    let (events, index) = tracer
+        .collect_events(
+            1,
+            10,
+            &ExportFilters {
+                excluded_namespaces: vec![TEST_NAMESPACE.into()],
+                ..Default::default()
+            },
+            false,
+        )
+        .unwrap();
 
     // Always an empty event at the beginning
     assert_eq!(events, vec![TraceEvent { ts: 1, ..Default::default() }]);
@@ -108,7 +93,7 @@ fn test_collect_events(mut tracer: TraceStore) {
         .iter()
         .map(|(name, ts)| TraceEvent {
             ts: *ts,
-            applied_objs: vec![test_obj(name)],
+            applied_objs: vec![test_deployment(name)],
             deleted_objs: vec![],
         })
         .collect();
@@ -117,39 +102,42 @@ fn test_collect_events(mut tracer: TraceStore) {
         TraceEvent {
             ts: 4,
             applied_objs: vec![],
-            deleted_objs: vec![test_obj("obj2")],
+            deleted_objs: vec![test_deployment("obj2")],
         },
     );
     all_events.push(TraceEvent {
         ts: 25,
         applied_objs: vec![],
-        deleted_objs: vec![test_obj("obj1")],
+        deleted_objs: vec![test_deployment("obj1")],
     });
     tracer.events = all_events.clone().into();
-    let (events, index) = tracer.collect_events(1, 10, &Default::default(), true);
+    let (events, index) = tracer.collect_events(1, 10, &Default::default(), true).unwrap();
 
     // The first object was created before the collection started so the timestamp changes
     all_events[0].ts = 1;
     assert_eq!(events, all_events[0..4]);
-    let keys: Vec<_> = index.into_keys().collect();
     assert_bag_eq!(
-        keys,
-        [format!("{TEST_NAMESPACE}/obj1"), format!("{TEST_NAMESPACE}/obj2"), format!("{TEST_NAMESPACE}/obj3")]
-            .map(|s| s.to_string())
+        index.flattened_keys(),
+        [
+            format!("{}:{TEST_NAMESPACE}/obj1", &*DEPL_GVK),
+            format!("{}:{TEST_NAMESPACE}/obj2", &*DEPL_GVK),
+            format!("{}:{TEST_NAMESPACE}/obj3", &*DEPL_GVK)
+        ]
+        .map(|s| s.to_string())
     );
 }
 
 #[rstest]
-fn test_create_or_update_obj(mut tracer: TraceStore, test_obj: DynamicObject) {
-    let ns_name = test_obj.namespaced_name();
+fn test_create_or_update_obj(mut tracer: TraceStore, test_deployment: DynamicObject) {
+    let ns_name = test_deployment.namespaced_name();
     let ts: i64 = 1234;
 
     // test idempotency, if we create the same obj twice nothing should change
-    tracer.create_or_update_obj(&test_obj, ts, None);
-    tracer.create_or_update_obj(&test_obj, 2445, None);
+    tracer.create_or_update_obj(&test_deployment, ts, None).unwrap();
+    tracer.create_or_update_obj(&test_deployment, 2445, None).unwrap();
 
     assert_eq!(tracer.index.len(), 1);
-    assert_eq!(tracer.index[&ns_name], EMPTY_OBJ_HASH);
+    assert_eq!(tracer.index.get(&DEPL_GVK, &ns_name).unwrap(), TEST_DEPL_HASH);
     assert_eq!(tracer.events.len(), 1);
     assert_eq!(tracer.events[0].applied_objs.len(), 1);
     assert_eq!(tracer.events[0].deleted_objs.len(), 0);
@@ -160,16 +148,16 @@ fn test_create_or_update_obj(mut tracer: TraceStore, test_obj: DynamicObject) {
 fn test_create_or_update_objs(mut tracer: TraceStore) {
     let obj_names = vec!["obj1", "obj2"];
     let ts = vec![1234, 3445];
-    let objs: Vec<_> = obj_names.iter().map(|p| test_obj(p)).collect();
+    let objs: Vec<_> = obj_names.iter().map(|p| test_deployment(p)).collect();
 
     for i in 0..objs.len() {
-        tracer.create_or_update_obj(&objs[i], ts[i], None);
+        tracer.create_or_update_obj(&objs[i], ts[i], None).unwrap();
     }
 
     assert_eq!(tracer.index.len(), objs.len());
     for p in objs.iter() {
         let ns_name = p.namespaced_name();
-        assert_eq!(tracer.index[&ns_name], EMPTY_OBJ_HASH);
+        assert_eq!(tracer.index.get(&DEPL_GVK, &ns_name).unwrap(), TEST_DEPL_HASH);
     }
     assert_eq!(tracer.events.len(), 2);
 
@@ -181,13 +169,13 @@ fn test_create_or_update_objs(mut tracer: TraceStore) {
 }
 
 #[rstest]
-fn test_delete_obj(mut tracer: TraceStore, test_obj: DynamicObject) {
-    let ns_name = test_obj.namespaced_name();
+fn test_delete_obj(mut tracer: TraceStore, test_deployment: DynamicObject) {
+    let ns_name = test_deployment.namespaced_name();
     let ts: i64 = 1234;
 
-    tracer.index.insert(ns_name.clone(), EMPTY_OBJ_HASH);
+    tracer.index.insert(DEPL_GVK.clone(), ns_name.clone(), TEST_DEPL_HASH);
 
-    tracer.delete_obj(&test_obj, ts);
+    tracer.delete_obj(&test_deployment, ts).unwrap();
 
     assert_eq!(tracer.index.len(), 0);
     assert_eq!(tracer.events.len(), 1);
@@ -199,17 +187,17 @@ fn test_delete_obj(mut tracer: TraceStore, test_obj: DynamicObject) {
 #[rstest]
 fn test_recreate_index_all_new(mut tracer: TraceStore) {
     let obj_names = vec!["obj1", "obj2", "obj3"];
-    let objs: Vec<_> = obj_names.iter().map(|p| test_obj(p)).collect();
+    let objs: Vec<_> = obj_names.iter().map(|p| test_deployment(p)).collect();
     let ts: i64 = 1234;
 
     // Calling it twice shouldn't change the tracked objs
-    tracer.update_all_objs(&objs, ts);
-    tracer.update_all_objs(&objs, 2445);
+    tracer.update_all_objs_for_gvk(&DEPL_GVK, &objs, ts).unwrap();
+    tracer.update_all_objs_for_gvk(&DEPL_GVK, &objs, 2445).unwrap();
 
     assert_eq!(tracer.index.len(), objs.len());
     for p in objs.iter() {
         let ns_name = p.namespaced_name();
-        assert_eq!(tracer.index[&ns_name], EMPTY_OBJ_HASH);
+        assert_eq!(tracer.index.get(&DEPL_GVK, &ns_name).unwrap(), TEST_DEPL_HASH);
     }
     assert_eq!(tracer.events.len(), 1);
     assert_eq!(tracer.events[0].applied_objs.len(), 3);
@@ -220,19 +208,18 @@ fn test_recreate_index_all_new(mut tracer: TraceStore) {
 #[rstest]
 fn test_recreate_index_with_created_obj(mut tracer: TraceStore) {
     let obj_names = vec!["obj1", "obj2", "obj3", "obj4"];
-    let objs: Vec<_> = obj_names.iter().map(|p| test_obj(p)).collect();
+    let objs: Vec<_> = obj_names.iter().map(|p| test_deployment(p)).collect();
     let ts = vec![1234, 2445];
 
-    // Calling it twice shouldn't change the tracked objs
     let mut fewer_objs = objs.clone();
     fewer_objs.pop();
-    tracer.update_all_objs(&fewer_objs, ts[0]);
-    tracer.update_all_objs(&objs, ts[1]);
+    tracer.update_all_objs_for_gvk(&DEPL_GVK, &fewer_objs, ts[0]).unwrap();
+    tracer.update_all_objs_for_gvk(&DEPL_GVK, &objs, ts[1]).unwrap();
 
     assert_eq!(tracer.index.len(), objs.len());
     for p in fewer_objs.iter() {
         let ns_name = p.namespaced_name();
-        assert_eq!(tracer.index[&ns_name], EMPTY_OBJ_HASH);
+        assert_eq!(tracer.index.get(&DEPL_GVK, &ns_name).unwrap(), TEST_DEPL_HASH);
     }
     assert_eq!(tracer.events.len(), 2);
     assert_eq!(tracer.events[0].applied_objs.len(), 3);
@@ -246,19 +233,18 @@ fn test_recreate_index_with_created_obj(mut tracer: TraceStore) {
 #[rstest]
 fn test_recreate_index_with_deleted_obj(mut tracer: TraceStore) {
     let obj_names = vec!["obj1", "obj2", "obj3"];
-    let objs: Vec<_> = obj_names.iter().map(|p| test_obj(p)).collect();
+    let objs: Vec<_> = obj_names.iter().map(|p| test_deployment(p)).collect();
     let ts = vec![1234, 2445];
 
-    // Calling it twice shouldn't change the tracked objs
-    tracer.update_all_objs(&objs, ts[0]);
+    tracer.update_all_objs_for_gvk(&DEPL_GVK, &objs, ts[0]).unwrap();
     let mut fewer_objs = objs.clone();
     fewer_objs.pop();
-    tracer.update_all_objs(&fewer_objs, ts[1]);
+    tracer.update_all_objs_for_gvk(&DEPL_GVK, &fewer_objs, ts[1]).unwrap();
 
     assert_eq!(tracer.index.len(), fewer_objs.len());
     for p in fewer_objs.iter() {
         let ns_name = p.namespaced_name();
-        assert_eq!(tracer.index[&ns_name], EMPTY_OBJ_HASH);
+        assert_eq!(tracer.index.get(&DEPL_GVK, &ns_name).unwrap(), TEST_DEPL_HASH);
     }
     assert_eq!(tracer.events.len(), 2);
     assert_eq!(tracer.events[0].applied_objs.len(), 3);
@@ -267,6 +253,33 @@ fn test_recreate_index_with_deleted_obj(mut tracer: TraceStore) {
     assert_eq!(tracer.events[1].applied_objs.len(), 0);
     assert_eq!(tracer.events[1].deleted_objs.len(), 1);
     assert_eq!(tracer.events[1].ts, ts[1]);
+}
+
+
+#[rstest]
+fn test_recreate_index_two_obj_types(mut tracer: TraceStore) {
+    let obj_names_1 = vec!["obj1", "obj2", "obj3"];
+    let objs1: Vec<_> = obj_names_1.iter().map(|p| test_deployment(p)).collect();
+    let obj_names_2 = vec!["obj4", "obj5", "obj6"];
+    let objs2: Vec<_> = obj_names_2.iter().map(|p| test_daemonset(p)).collect();
+    let ts = 1234;
+
+    tracer.update_all_objs_for_gvk(&DEPL_GVK, &objs1, ts).unwrap();
+    tracer.update_all_objs_for_gvk(&DS_GVK, &objs2, ts).unwrap();
+
+    assert_eq!(tracer.index.len(), objs1.len() + objs2.len());
+    for p in objs1.iter() {
+        let ns_name = p.namespaced_name();
+        assert_eq!(tracer.index.get(&DEPL_GVK, &ns_name).unwrap(), TEST_DEPL_HASH);
+    }
+    for p in objs2.iter() {
+        let ns_name = p.namespaced_name();
+        assert_eq!(tracer.index.get(&DS_GVK, &ns_name).unwrap(), TEST_DS_HASH);
+    }
+    assert_eq!(tracer.events.len(), 1);
+    assert_eq!(tracer.events[0].applied_objs.len(), 6);
+    assert_eq!(tracer.events[0].deleted_objs.len(), 0);
+    assert_eq!(tracer.events[0].ts, ts);
 }
 
 #[rstest]
@@ -337,7 +350,7 @@ fn test_record_pod_lifecycle_with_new_pod_hash(
     let new_lifecycle_data = PodLifecycleData::Finished(5, 45);
     let gvk = GVK::from_owner_ref(&owner_ref).unwrap();
     tracer.config.tracked_objects.get_mut(&gvk).unwrap().track_lifecycle = track_lifecycle;
-    tracer.index.insert(owner_ns_name.clone(), EMPTY_OBJ_HASH);
+    tracer.index.insert(DEPL_GVK.clone(), owner_ns_name.clone(), TEST_DEPL_HASH);
     tracer
         .record_pod_lifecycle(&ns_name, Some(test_pod), vec![owner_ref], &new_lifecycle_data.clone())
         .unwrap();
@@ -364,7 +377,7 @@ fn test_record_pod_lifecycle_with_new_pod_existing_hash(
     let ns_name = test_pod.namespaced_name();
     let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, owner_ref.name);
 
-    tracer.index.insert(owner_ns_name.clone(), EMPTY_OBJ_HASH);
+    tracer.index.insert(DEPL_GVK.clone(), owner_ns_name.clone(), TEST_DEPL_HASH);
     tracer.pod_owners = PodOwnersMap::new_from_parts(
         HashMap::from([(owner_ns_name.clone(), HashMap::from([(EMPTY_POD_SPEC_HASH, init_lifecycle_data)]))]),
         HashMap::from([("asdf".into(), (owner_ns_name.clone(), 1234, 0))]),
@@ -393,7 +406,7 @@ fn test_record_pod_lifecycle_with_existing_pod(
     let ns_name = test_pod.namespaced_name();
     let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, owner_ref.name);
 
-    tracer.index.insert(owner_ns_name.clone(), EMPTY_OBJ_HASH);
+    tracer.index.insert(DEPL_GVK.clone(), owner_ns_name.clone(), TEST_DEPL_HASH);
     tracer.pod_owners = PodOwnersMap::new_from_parts(
         HashMap::from([(owner_ns_name.clone(), HashMap::from([(EMPTY_POD_SPEC_HASH, init_lifecycle_data)]))]),
         HashMap::from([(ns_name.clone(), (owner_ns_name.clone(), EMPTY_POD_SPEC_HASH, 0))]),

--- a/sk-store/src/watchers/pod_watcher.rs
+++ b/sk-store/src/watchers/pod_watcher.rs
@@ -28,11 +28,11 @@ use kube::runtime::watcher::{
 use sk_core::errors::*;
 use sk_core::k8s::{
     ApiSet,
-    KubeResourceExt,
     OwnersCache,
     PodLifecycleData,
 };
 use sk_core::prelude::*;
+use tracing::*;
 
 use crate::{
     TraceStorable,

--- a/sk-store/src/watchers/tests/mod.rs
+++ b/sk-store/src/watchers/tests/mod.rs
@@ -1,7 +1,6 @@
 mod pod_watcher_test;
 
 use rstest::*;
-use sk_core::k8s::testutils::*;
 use tracing_test::traced_test;
 
 use super::*;

--- a/sk-store/src/watchers/tests/pod_watcher_test.rs
+++ b/sk-store/src/watchers/tests/pod_watcher_test.rs
@@ -13,7 +13,6 @@ use kube::runtime::watcher::Event;
 use mockall::predicate;
 use sk_core::k8s::{
     ApiSet,
-    KubeResourceExt,
     OwnersCache,
     PodLifecycleData,
 };

--- a/sk-tracer/src/main.rs
+++ b/sk-tracer/src/main.rs
@@ -27,6 +27,7 @@ use sk_store::{
     TraceStore,
     TracerConfig,
 };
+use tracing::*;
 
 use crate::errors::ExportResponseError;
 


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
This fixes a bug where if you track multiple resource types (Deployments and StatefulSets) for example, some of the objects get deleted on tracer startup, due to a mishandling of the `Restart` event.

This necessitated some changes to the trace file to track GVKs in addition to namespaced names of objects in its "index".  Since I was in the code, I also took the opportunity here to update the format of the trace file to make it more future-proof.  Trace files now include a version parameter, and are a dictionary of objects instead of just a list.  This way I can add new fields or elements to the trace, and if you're running an old version of simkube they will be silently ignored.  However, this change in format is a BREAKING CHANGE, hence this will bump SimKube to 2.0.

## Testing done
- `make test`; added a new test into the trace_store_test code that would catch the initial bug that triggered this change
- manual testing; confirmed that simulations still run, export works, and xray still works.
