### PR TITLE
k8s: don't set node-selector for sk-tracer in kustomize files

### DIFF
--- a/k8s/kustomize/prod/sk-tracer.yml
+++ b/k8s/kustomize/prod/sk-tracer.yml
@@ -79,8 +79,6 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: tracer-config
-      nodeSelector:
-        type: kind-worker
       serviceAccountName: sk-tracer-sa
       volumes:
         - configMap:

--- a/k8s/main.py
+++ b/k8s/main.py
@@ -89,6 +89,8 @@ def write_kustomize_files(build_dir: str):
 def main():
     args = setup_args()
     debug = not args.kustomize
+    if args.kustomize:
+        os.environ["KUSTOMIZE"] = "1"
 
     build_dir = os.getenv("BUILD_DIR")
     dag_path = None if args.kustomize else f"{build_dir}/{DAG_FILENAME}"

--- a/k8s/sk_tracer.py
+++ b/k8s/sk_tracer.py
@@ -1,3 +1,5 @@
+import os
+
 import fireconfig as fire
 from constructs import Construct
 from fireconfig.types import Capability
@@ -45,8 +47,10 @@ class SkTracer(fire.AppPackage):
             .with_service_account_and_role_binding("view", True)
             .with_containers(container)
             .with_service()
-            .with_node_selector("type", "kind-worker")
         )
+
+        if os.getenv("KUSTOMIZE") is None:
+            self._depl = self._depl.with_node_selector("type", "kind-worker")
 
     def compile(self, chart: Construct):
         self._depl.build(chart)  # type: ignore


### PR DESCRIPTION
- [2] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
don't set node-selector for sk-tracer in kustomize files

## Testing done
- manual testing
- pre-commit passes