### PR TITLE
fix: misaligned error display in skctl xray

### DIFF
--- a/sk-cli/src/xray/view/helpers.rs
+++ b/sk-cli/src/xray/view/helpers.rs
@@ -102,10 +102,7 @@ pub(super) fn format_list_entries<'a>(
             // error is present we create a separate span here.
             let (trunc_width, right_padding_width) = match err_span.width() {
                 0 => (width - LIST_PADDING, 0),
-                x => (
-                    width - (mid_padding_width + max_err_width + max_err_width - x + LIST_PADDING + LIST_PADDING),
-                    max_err_width - x + LIST_PADDING,
-                ),
+                x => (width - (mid_padding_width + max_err_width + LIST_PADDING), max_err_width - x + LIST_PADDING),
             };
             let right_padding_span = Span::styled(" ".repeat(right_padding_width), err_span.style);
 

--- a/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list_event_selected@2.snap
+++ b/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list_event_selected@2.snap
@@ -1,5 +1,5 @@
 ---
-source: sk-cli/src/xray/tests/view_test.rs
+source: sk-cli/src/xray/view/tests/view_test.rs
 expression: cf
 ---
 CompletedFrame {
@@ -11,7 +11,7 @@ CompletedFrame {
             "│   00:00:01 (1 applied/0 deleted)                                             │",
             "│>> 00:00:02 (3 applied/0 deleted)                       1 error/0 warnings    │",
             "│++   + test-namespace/test_depl1                                              │",
-            "│     + test-namespace/test_depl2xxxxxxxxxxxxxxxxxxx...  1 error/0 warnings    │",
+            "│     + test-namespace/test_depl2xxxxxxxxxxxxxxxxxxxxxx...  1 error/0 warnings │",
             "│     + test-namespace/test_depl3xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx... │",
             "│   00:00:03 (0 applied/1 deleted)                                             │",
             "│                                                                              │",
@@ -37,7 +37,7 @@ CompletedFrame {
             x: 33, y: 4, fg: Reset, bg: Blue, underline: Reset, modifier: NONE,
             x: 79, y: 4, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
             x: 4, y: 5, fg: Reset, bg: Reset, underline: Reset, modifier: ITALIC,
-            x: 56, y: 5, fg: White, bg: Red, underline: Reset, modifier: NONE,
+            x: 59, y: 5, fg: White, bg: Red, underline: Reset, modifier: NONE,
             x: 79, y: 5, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
             x: 4, y: 6, fg: Reset, bg: Reset, underline: Reset, modifier: ITALIC,
             x: 79, y: 6, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
We double-counted columns in the error view when determining how much to truncate for the item name display in skctl xray, which led names getting truncated when they shouldn't have been.

## Testing done
- manual testing
- it'd be sorta nice to have a snapshot test for this since the other snapshot tests didn't catch it, but it's kindof a pain to do so I didn't bother.