### PR TITLE
feat: annotations in `skctl validate` include possible patches

### DIFF
--- a/sk-cli/src/validation/mod.rs
+++ b/sk-cli/src/validation/mod.rs
@@ -1,5 +1,5 @@
 mod annotated_trace;
-mod status_field_populated;
+mod rules;
 mod summary;
 mod validation_store;
 mod validator;

--- a/sk-cli/src/validation/rules/mod.rs
+++ b/sk-cli/src/validation/rules/mod.rs
@@ -1,0 +1,4 @@
+pub mod status_field_populated;
+
+#[cfg(test)]
+mod tests;

--- a/sk-cli/src/validation/rules/tests/mod.rs
+++ b/sk-cli/src/validation/rules/tests/mod.rs
@@ -1,0 +1,7 @@
+mod status_field_populated_test;
+
+use rstest::*;
+use sk_core::prelude::*;
+
+use super::*;
+use crate::validation::AnnotatedTraceEvent;

--- a/sk-cli/src/validation/rules/tests/status_field_populated_test.rs
+++ b/sk-cli/src/validation/rules/tests/status_field_populated_test.rs
@@ -15,8 +15,8 @@ fn test_status_field_populated(test_deployment: DynamicObject) {
         },
         ..Default::default()
     };
-    let indices = v.check_next_event(&mut evt);
-    assert_bag_eq!(indices, &[0]);
+    let annotations = v.check_next_event(&mut evt).unwrap();
+    assert_eq!(annotations.keys().collect::<Vec<_>>(), vec![&0]);
 }
 
 #[rstest]
@@ -30,6 +30,6 @@ fn test_status_field_not_populated(test_deployment: DynamicObject) {
         },
         ..Default::default()
     };
-    let indices = v.check_next_event(&mut evt);
-    assert_is_empty!(indices);
+    let annotations = v.check_next_event(&mut evt).unwrap();
+    assert_is_empty!(annotations);
 }

--- a/sk-cli/src/validation/tests/annotated_trace_test.rs
+++ b/sk-cli/src/validation/tests/annotated_trace_test.rs
@@ -8,7 +8,7 @@ fn test_apply_patch_everywhere(mut annotated_trace: AnnotatedTrace) {
     annotated_trace
         .apply_patch(AnnotatedTracePatch {
             locations: PatchLocations::Everywhere,
-            op: add_operation(format_ptr!("/foo"), "bar".into()),
+            ops: vec![add_operation(format_ptr!("/foo"), "bar".into())],
         })
         .unwrap();
 
@@ -27,7 +27,7 @@ fn test_apply_patch_object_reference(mut annotated_trace: AnnotatedTrace) {
                 DEPL_GVK.into_type_meta(),
                 format!("{TEST_NAMESPACE}/test_depl1"),
             ),
-            op: add_operation(format_ptr!("/foo"), "bar".into()),
+            ops: vec![add_operation(format_ptr!("/foo"), "bar".into())],
         })
         .unwrap();
 

--- a/sk-cli/src/validation/tests/validation_store_test.rs
+++ b/sk-cli/src/validation/tests/validation_store_test.rs
@@ -1,6 +1,7 @@
 use assertables::*;
 
 use super::*;
+use crate::validation::annotated_trace::Annotation;
 
 #[rstest]
 fn test_validate_trace(test_validation_store: ValidationStore, mut annotated_trace: AnnotatedTrace) {
@@ -8,9 +9,9 @@ fn test_validate_trace(test_validation_store: ValidationStore, mut annotated_tra
 
     for event in annotated_trace.iter() {
         if event.data.applied_objs.len() > 1 {
-            assert_eq!(event.annotations[1], vec![TEST_VALIDATOR_CODE]);
+            assert_all!(event.annotations[&1].iter(), |a: &Annotation| a.code == TEST_VALIDATOR_CODE);
         } else {
-            for annotation in &event.annotations {
+            for annotation in event.annotations.values() {
                 assert_is_empty!(annotation);
             }
         }
@@ -25,15 +26,14 @@ fn test_fix_trace(test_validation_store: ValidationStore, mut annotated_trace: A
     let summary = test_validation_store.validate_trace(&mut annotated_trace, true).unwrap();
 
     for event in annotated_trace.iter() {
-        println!("{:?}", event.data);
         if event.data.applied_objs.len() > 1 {
             assert_eq!(event.data.applied_objs[1].data.get("foo").unwrap(), "bar");
         }
-        for annotation in &event.annotations {
+        for annotation in event.annotations.values() {
             assert_is_empty!(annotation);
         }
     }
 
     assert_eq!(*summary.annotations.get(&TEST_VALIDATOR_CODE).unwrap(), 1);
-    assert_eq!(summary.patches, 1);
+    assert_eq!(summary.patches, 5);
 }


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
`Annotations` in `skctl validate` include a set of possible patches per event/object, instead of just an error code and affected index.  This is because some proposed fixes are going to be specific to the specific state/object affected.

## Testing done
- make test
- manual testing
