### PR TITLE
feat: InsertAt patch location + secondary patch for service_account_missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "assertables"
-version = "8.18.0"
+version = "9.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857057651cdf1fe4bc1e8308493c752db559df0330f23b45f532f6b24c2b443d"
+checksum = "0082388b8564898f945b04215e800e800a164af15307d8dfe714b02cc69356e9"
 
 [[package]]
 name = "async-broadcast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5.3"
 
 # test dependencies
-assertables = "8.18.0"
+assertables = "9.5.0"
 http = "1.1.0"
 httpmock = "0.6.8"
 hyper = "1.5.0"

--- a/rust-coverage.lcov
+++ b/rust-coverage.lcov
@@ -1,0 +1,11240 @@
+TN:
+SF:sk-store/src/index.rs
+FN:52,<sk_store::index::TraceIndex>::remove::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_bytes::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_char::<_>
+FN:43,<sk_store::index::TraceIndex>::is_empty
+FN:25,<sk_store::index::TraceIndex>::contains::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u32::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i8::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<sk_store::index::TraceIndex>::new
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<serde_json::error::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i8::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:57,<sk_store::index::TraceIndex>::take_gvk_index
+FN:47,<sk_store::index::TraceIndex>::len
+FN:31,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i16::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_char::<_>
+FN:44,<sk_store::index::TraceIndex>::is_empty::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f64::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u8::<rmp_serde::decode::Error>
+FN:44,<sk_store::index::TraceIndex>::is_empty::{closure#0}
+FN:52,<sk_store::index::TraceIndex>::remove::{closure#0}
+FN:28,<sk_store::index::TraceIndex>::flattened_keys
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bool::<rmp_serde::decode::Error>
+FN:24,<sk_store::index::TraceIndex>::contains
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:39,<sk_store::index::TraceIndex>::insert
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i32::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i32::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u16::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i64::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<serde_json::error::Error>
+FN:24,<sk_store::index::TraceIndex>::contains
+FN:52,<sk_store::index::TraceIndex>::remove::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:57,<sk_store::index::TraceIndex>::take_gvk_index
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bool::<rmp_serde::decode::Error>
+FN:47,<sk_store::index::TraceIndex>::len
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:57,<sk_store::index::TraceIndex>::take_gvk_index
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_unit::<rmp_serde::decode::Error>
+FN:48,<sk_store::index::TraceIndex>::len::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f32::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f32::<rmp_serde::decode::Error>
+FN:24,<sk_store::index::TraceIndex>::contains
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_bytes::<rmp_serde::decode::Error>
+FN:31,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i64::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i16::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:31,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f64::<rmp_serde::decode::Error>
+FN:48,<sk_store::index::TraceIndex>::len::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u16::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u8::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_bytes::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f32::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_unit::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<serde_json::error::Error>
+FN:25,<sk_store::index::TraceIndex>::contains::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u16::<rmp_serde::decode::Error>
+FN:51,<sk_store::index::TraceIndex>::remove
+FN:43,<sk_store::index::TraceIndex>::is_empty
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i32::<rmp_serde::decode::Error>
+FN:28,<sk_store::index::TraceIndex>::flattened_keys
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:51,<sk_store::index::TraceIndex>::remove
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u32::<rmp_serde::decode::Error>
+FN:31,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}::{closure#0}
+FN:43,<sk_store::index::TraceIndex>::is_empty
+FN:51,<sk_store::index::TraceIndex>::remove
+FN:35,<sk_store::index::TraceIndex>::get
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u32::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u8::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i16::<rmp_serde::decode::Error>
+FN:44,<sk_store::index::TraceIndex>::is_empty::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i64::<rmp_serde::decode::Error>
+FN:20,<sk_store::index::TraceIndex>::new
+FN:28,<sk_store::index::TraceIndex>::flattened_keys
+FN:39,<sk_store::index::TraceIndex>::insert
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<sk_store::index::TraceIndex>::new
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:48,<sk_store::index::TraceIndex>::len::{closure#0}
+FN:35,<sk_store::index::TraceIndex>::get
+FN:39,<sk_store::index::TraceIndex>::insert
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_unit::<rmp_serde::decode::Error>
+FN:25,<sk_store::index::TraceIndex>::contains::{closure#0}
+FN:47,<sk_store::index::TraceIndex>::len
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:35,<sk_store::index::TraceIndex>::get
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bool::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_char::<_>
+FN:31,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}::{closure#0}
+FN:31,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}::{closure#0}
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i8::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f64::<rmp_serde::decode::Error>
+FN:13,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::index::TraceIndex>::remove::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_bytes::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_char::<_>
+FNDA:0,<sk_store::index::TraceIndex>::is_empty
+FNDA:1,<sk_store::index::TraceIndex>::contains::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u32::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i8::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<sk_store::index::TraceIndex>::new
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<serde_json::error::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i8::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::index::TraceIndex>::take_gvk_index
+FNDA:0,<sk_store::index::TraceIndex>::len
+FNDA:1,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i16::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_char::<_>
+FNDA:0,<sk_store::index::TraceIndex>::is_empty::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u8::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::is_empty::{closure#0}
+FNDA:1,<sk_store::index::TraceIndex>::remove::{closure#0}
+FNDA:1,<sk_store::index::TraceIndex>::flattened_keys
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bool::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::contains
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:1,<sk_store::index::TraceIndex>::insert
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i32::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i32::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u16::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<serde_json::error::Error>
+FNDA:1,<sk_store::index::TraceIndex>::contains
+FNDA:0,<sk_store::index::TraceIndex>::remove::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::take_gvk_index
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bool::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::len
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:1,<sk_store::index::TraceIndex>::take_gvk_index
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_unit::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::len::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f32::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f32::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::contains
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i16::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f64::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::len::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u16::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u8::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_bytes::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f32::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_unit::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<serde_json::error::Error>
+FNDA:0,<sk_store::index::TraceIndex>::contains::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u16::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::remove
+FNDA:1,<sk_store::index::TraceIndex>::is_empty
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i32::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::flattened_keys
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::index::TraceIndex>::remove
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u32::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}::{closure#0}
+FNDA:0,<sk_store::index::TraceIndex>::is_empty
+FNDA:1,<sk_store::index::TraceIndex>::remove
+FNDA:0,<sk_store::index::TraceIndex>::get
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u32::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u8::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i16::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::is_empty::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i64::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::new
+FNDA:0,<sk_store::index::TraceIndex>::flattened_keys
+FNDA:0,<sk_store::index::TraceIndex>::insert
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:1,<sk_store::index::TraceIndex>::new
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<sk_store::index::TraceIndex>::len::{closure#0}
+FNDA:0,<sk_store::index::TraceIndex>::get
+FNDA:0,<sk_store::index::TraceIndex>::insert
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_borrowed_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_unit::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::index::TraceIndex>::contains::{closure#0}
+FNDA:1,<sk_store::index::TraceIndex>::len
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:1,<sk_store::index::TraceIndex>::get
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bool::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_char::<_>
+FNDA:0,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}::{closure#0}
+FNDA:1,<sk_store::index::TraceIndex>::flattened_keys::{closure#0}::{closure#0}
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_i8::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_f64::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::index::TraceIndex as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNF:120
+FNH:27
+BRF:0
+BRH:0
+DA:20,17
+DA:21,17
+DA:22,17
+DA:24,7
+DA:25,7
+DA:26,7
+DA:28,5
+DA:29,5
+DA:30,5
+DA:31,31
+DA:32,5
+DA:33,5
+DA:35,59
+DA:36,59
+DA:37,59
+DA:39,120
+DA:40,120
+DA:41,120
+DA:43,1
+DA:44,1
+DA:45,1
+DA:47,7
+DA:48,8
+DA:49,7
+DA:51,18
+DA:52,18
+DA:53,18
+DA:54,18
+DA:55,18
+DA:57,10
+DA:58,10
+DA:59,10
+LF:32
+LH:32
+end_of_record
+SF:sk-core/src/k8s/sim.rs
+FN:30,sk_core::k8s::sim::build_simulation_root
+FN:30,sk_core::k8s::sim::build_simulation_root
+FN:26,sk_core::k8s::sim::is_terminal
+FN:19,sk_core::k8s::sim::metrics_svc_account
+FN:19,sk_core::k8s::sim::metrics_svc_account
+FN:19,sk_core::k8s::sim::metrics_svc_account
+FN:12,sk_core::k8s::sim::metrics_ns
+FN:26,sk_core::k8s::sim::is_terminal
+FN:12,sk_core::k8s::sim::metrics_ns
+FN:12,sk_core::k8s::sim::metrics_ns
+FN:30,sk_core::k8s::sim::build_simulation_root
+FN:26,sk_core::k8s::sim::is_terminal
+FNDA:0,sk_core::k8s::sim::build_simulation_root
+FNDA:0,sk_core::k8s::sim::build_simulation_root
+FNDA:1,sk_core::k8s::sim::is_terminal
+FNDA:0,sk_core::k8s::sim::metrics_svc_account
+FNDA:0,sk_core::k8s::sim::metrics_svc_account
+FNDA:1,sk_core::k8s::sim::metrics_svc_account
+FNDA:0,sk_core::k8s::sim::metrics_ns
+FNDA:0,sk_core::k8s::sim::is_terminal
+FNDA:1,sk_core::k8s::sim::metrics_ns
+FNDA:0,sk_core::k8s::sim::metrics_ns
+FNDA:0,sk_core::k8s::sim::build_simulation_root
+FNDA:0,sk_core::k8s::sim::is_terminal
+FNF:12
+FNH:3
+BRF:0
+BRH:0
+DA:12,63
+DA:13,56
+DA:14,0
+DA:15,63
+DA:17,63
+DA:19,28
+DA:20,28
+DA:21,0
+DA:22,28
+DA:24,28
+DA:26,49
+DA:27,49
+DA:28,49
+DA:30,0
+DA:31,0
+DA:32,0
+DA:33,0
+DA:34,0
+DA:35,0
+DA:36,0
+LF:20
+LH:11
+end_of_record
+SF:sk-ctrl/src/errors.rs
+FN:17,<sk_ctrl::errors::AnyhowError as core::ops::deref::Deref>::deref
+FNDA:0,<sk_ctrl::errors::AnyhowError as core::ops::deref::Deref>::deref
+FNF:1
+FNH:0
+BRF:0
+BRH:0
+DA:17,0
+DA:18,0
+DA:19,0
+LF:3
+LH:0
+end_of_record
+SF:sk-cli/src/validation/annotated_trace.rs
+FN:175,<skctl::validation::annotated_trace::AnnotatedTrace>::path
+FN:64,<skctl::validation::annotated_trace::AnnotatedTraceEvent>::clear_annotations
+FN:262,<skctl::validation::annotated_trace::AnnotatedTrace>::new_with_events
+FN:135,<skctl::validation::annotated_trace::AnnotatedTrace>::get_event
+FN:179,<skctl::validation::annotated_trace::AnnotatedTrace>::start_ts
+FN:198,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#0}
+FN:204,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#1}
+FN:191,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects
+FN:171,<skctl::validation::annotated_trace::AnnotatedTrace>::len
+FN:227,skctl::validation::annotated_trace::find_or_create_event_at_ts
+FN:114,<skctl::validation::annotated_trace::AnnotatedTrace>::validate
+FN:254,<skctl::validation::annotated_trace::AnnotatedTrace>::new_with_events
+FN:85,<skctl::validation::annotated_trace::AnnotatedTrace>::new::{closure#0}::{closure#0}
+FN:199,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#0}::{closure#0}
+FN:175,<skctl::validation::annotated_trace::AnnotatedTrace>::path
+FN:85,<skctl::validation::annotated_trace::AnnotatedTrace>::new::{closure#0}::{closure#0}
+FN:81,<skctl::validation::annotated_trace::AnnotatedTrace>::new::{closure#0}
+FN:94,<skctl::validation::annotated_trace::AnnotatedTrace>::apply_patch
+FN:163,<skctl::validation::annotated_trace::AnnotatedTrace>::is_empty_at::{closure#0}
+FN:139,<skctl::validation::annotated_trace::AnnotatedTrace>::get_next_annotation
+FN:180,<skctl::validation::annotated_trace::AnnotatedTrace>::start_ts::{closure#0}
+FN:179,<skctl::validation::annotated_trace::AnnotatedTrace>::start_ts
+FN:60,<skctl::validation::annotated_trace::AnnotatedTraceEvent>::new
+FN:110,<skctl::validation::annotated_trace::AnnotatedTrace>::export::{closure#0}
+FN:60,<skctl::validation::annotated_trace::AnnotatedTraceEvent>::new
+FN:94,<skctl::validation::annotated_trace::AnnotatedTrace>::apply_patch
+FN:160,<skctl::validation::annotated_trace::AnnotatedTrace>::is_empty_at
+FN:167,<skctl::validation::annotated_trace::AnnotatedTrace>::iter
+FN:198,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#0}
+FN:233,skctl::validation::annotated_trace::find_or_create_event_at_ts::{closure#0}
+FN:107,<skctl::validation::annotated_trace::AnnotatedTrace>::export
+FN:150,<skctl::validation::annotated_trace::AnnotatedTrace>::get_object
+FN:183,<skctl::validation::annotated_trace::AnnotatedTrace>::object_iter_mut
+FN:160,<skctl::validation::annotated_trace::AnnotatedTrace>::is_empty_at
+FN:180,<skctl::validation::annotated_trace::AnnotatedTrace>::start_ts::{closure#0}
+FN:163,<skctl::validation::annotated_trace::AnnotatedTrace>::is_empty_at::{closure#0}
+FN:171,<skctl::validation::annotated_trace::AnnotatedTrace>::len
+FN:135,<skctl::validation::annotated_trace::AnnotatedTrace>::get_event
+FN:186,<skctl::validation::annotated_trace::AnnotatedTrace>::object_iter_mut::{closure#0}
+FN:81,<skctl::validation::annotated_trace::AnnotatedTrace>::new::{closure#0}
+FN:121,<skctl::validation::annotated_trace::AnnotatedTrace>::validate::{closure#0}
+FN:64,<skctl::validation::annotated_trace::AnnotatedTraceEvent>::clear_annotations
+FN:110,<skctl::validation::annotated_trace::AnnotatedTrace>::export::{closure#0}
+FN:199,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#0}::{closure#0}
+FN:183,<skctl::validation::annotated_trace::AnnotatedTrace>::object_iter_mut
+FN:107,<skctl::validation::annotated_trace::AnnotatedTrace>::export
+FN:150,<skctl::validation::annotated_trace::AnnotatedTrace>::get_object
+FN:191,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects
+FN:186,<skctl::validation::annotated_trace::AnnotatedTrace>::object_iter_mut::{closure#0}
+FN:81,<skctl::validation::annotated_trace::AnnotatedTrace>::new
+FN:121,<skctl::validation::annotated_trace::AnnotatedTrace>::validate::{closure#0}
+FN:114,<skctl::validation::annotated_trace::AnnotatedTrace>::validate
+FN:167,<skctl::validation::annotated_trace::AnnotatedTrace>::iter
+FN:139,<skctl::validation::annotated_trace::AnnotatedTrace>::get_next_annotation
+FN:81,<skctl::validation::annotated_trace::AnnotatedTrace>::new
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::path
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTraceEvent>::clear_annotations
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::new_with_events
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::get_event
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::start_ts
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#1}
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::len
+FNDA:1,skctl::validation::annotated_trace::find_or_create_event_at_ts
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::validate
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::new_with_events
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::new::{closure#0}::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#0}::{closure#0}
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::path
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::new::{closure#0}::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::new::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::apply_patch
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::is_empty_at::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::get_next_annotation
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::start_ts::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::start_ts
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTraceEvent>::new
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::export::{closure#0}
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTraceEvent>::new
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::apply_patch
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::is_empty_at
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::iter
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#0}
+FNDA:1,skctl::validation::annotated_trace::find_or_create_event_at_ts::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::export
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::get_object
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::object_iter_mut
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::is_empty_at
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::start_ts::{closure#0}
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::is_empty_at::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::len
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::get_event
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::object_iter_mut::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::new::{closure#0}
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::validate::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTraceEvent>::clear_annotations
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::export::{closure#0}
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects::{closure#0}::{closure#0}
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::object_iter_mut
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::export
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::get_object
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::matched_objects
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::object_iter_mut::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::new
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::validate::{closure#0}
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::validate
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::iter
+FNDA:1,<skctl::validation::annotated_trace::AnnotatedTrace>::get_next_annotation
+FNDA:0,<skctl::validation::annotated_trace::AnnotatedTrace>::new
+FNF:55
+FNH:22
+BRF:0
+BRH:0
+DA:60,952
+DA:61,952
+DA:62,952
+DA:64,922
+DA:65,922
+DA:66,922
+DA:81,0
+DA:82,0
+DA:83,0
+DA:84,0
+DA:85,0
+DA:86,0
+DA:87,0
+DA:88,0
+DA:89,0
+DA:90,0
+DA:91,0
+DA:92,0
+DA:94,4
+DA:95,4
+DA:96,14
+DA:97,14
+DA:98,28
+DA:99,14
+DA:102,4
+DA:103,4
+DA:104,4
+DA:105,4
+DA:107,0
+DA:108,0
+DA:109,0
+DA:110,0
+DA:111,0
+DA:112,0
+DA:114,18
+DA:115,18
+DA:116,922
+DA:117,922
+DA:118,922
+DA:119,922
+DA:120,922
+DA:121,922
+DA:123,969
+DA:124,47
+DA:125,47
+DA:126,47
+DA:127,47
+DA:128,47
+DA:129,47
+DA:132,18
+DA:133,18
+DA:135,8
+DA:136,8
+DA:137,8
+DA:139,2
+DA:140,8
+DA:141,7
+DA:142,1
+DA:143,1
+DA:144,0
+DA:147,1
+DA:148,2
+DA:150,0
+DA:151,0
+DA:152,0
+DA:153,0
+DA:154,0
+DA:156,0
+DA:158,0
+DA:160,2
+DA:161,2
+DA:162,2
+DA:163,2
+DA:164,2
+DA:165,2
+DA:167,19
+DA:168,19
+DA:169,19
+DA:171,15
+DA:172,15
+DA:173,15
+DA:175,15
+DA:176,15
+DA:177,15
+DA:179,16
+DA:180,16
+DA:181,16
+DA:183,3
+DA:184,3
+DA:185,3
+DA:186,12
+DA:187,3
+DA:191,4
+DA:192,4
+DA:193,4
+DA:194,4
+DA:195,4
+DA:196,2
+DA:197,1
+DA:198,5
+DA:199,5
+DA:200,5
+DA:202,1
+DA:203,1
+DA:204,1
+DA:205,1
+DA:206,1
+DA:207,1
+DA:208,1
+DA:209,1
+DA:210,1
+DA:211,1
+DA:213,1
+DA:214,1
+DA:215,0
+DA:217,0
+DA:218,0
+DA:220,0
+DA:221,1
+DA:222,0
+DA:223,0
+DA:224,4
+DA:225,0
+DA:227,6
+DA:228,6
+DA:229,6
+DA:230,6
+DA:231,6
+DA:232,6
+DA:233,12
+DA:234,5
+DA:235,5
+DA:236,5
+DA:237,5
+DA:238,3
+DA:239,3
+DA:241,2
+DA:246,1
+DA:247,1
+DA:250,6
+DA:262,0
+DA:263,0
+DA:264,0
+LF:143
+LH:107
+end_of_record
+SF:sk-cli/src/crd.rs
+FN:3,skctl::crd::cmd
+FN:3,skctl::crd::cmd
+FNDA:0,skctl::crd::cmd
+FNDA:0,skctl::crd::cmd
+FNF:2
+FNH:0
+BRF:0
+BRH:0
+DA:3,0
+DA:4,0
+DA:5,0
+DA:7,0
+DA:8,0
+LF:5
+LH:0
+end_of_record
+SF:sk-tracer/src/errors.rs
+FN:22,<sk_tracer::errors::ExportResponseError as core::convert::From<anyhow::Error>>::from
+FN:9,<sk_tracer::errors::ExportResponseError as rocket::response::responder::Responder>::respond_to
+FN:40,<sk_tracer::errors::ExportResponseError as core::convert::From<object_store::Error>>::from
+FN:34,<sk_tracer::errors::ExportResponseError as core::convert::From<url::parser::ParseError>>::from
+FN:28,<sk_tracer::errors::ExportResponseError as core::convert::From<std::sync::poison::PoisonError<std::sync::mutex::MutexGuard<sk_store::store::TraceStore>>>>::from
+FNDA:0,<sk_tracer::errors::ExportResponseError as core::convert::From<anyhow::Error>>::from
+FNDA:0,<sk_tracer::errors::ExportResponseError as rocket::response::responder::Responder>::respond_to
+FNDA:0,<sk_tracer::errors::ExportResponseError as core::convert::From<object_store::Error>>::from
+FNDA:0,<sk_tracer::errors::ExportResponseError as core::convert::From<url::parser::ParseError>>::from
+FNDA:0,<sk_tracer::errors::ExportResponseError as core::convert::From<std::sync::poison::PoisonError<std::sync::mutex::MutexGuard<sk_store::store::TraceStore>>>>::from
+FNF:5
+FNH:0
+BRF:0
+BRH:0
+DA:22,0
+DA:23,0
+DA:24,0
+DA:28,0
+DA:29,0
+DA:30,0
+DA:34,0
+DA:35,0
+DA:36,0
+DA:40,0
+DA:41,0
+DA:43,0
+DA:45,0
+DA:47,0
+LF:14
+LH:0
+end_of_record
+SF:sk-core/src/k8s/gvk.rs
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::U8Deserializer<rmp_serde::decode::Error>>
+FN:38,<sk_core::k8s::gvk::GVK>::from_owner_ref
+FN:50,<sk_core::k8s::gvk::GVK>::into_type_meta
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<rmp_serde::bytes::OnlyBytes>
+FN:27,<sk_core::k8s::gvk::GVK>::new
+FN:62,<sk_core::k8s::gvk::GVK as core::ops::deref::Deref>::deref
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut serde_json::ser::Serializer<&mut alloc::vec::Vec<u8>>>
+FN:68,<sk_core::k8s::gvk::GVK as core::fmt::Display>::fmt
+FN:31,<sk_core::k8s::gvk::GVK>::from_dynamic_obj
+FN:68,<sk_core::k8s::gvk::GVK as core::fmt::Display>::fmt
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde::de::value::Error>
+FN:68,<sk_core::k8s::gvk::GVK as core::fmt::Display>::fmt
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:138,sk_core::k8s::gvk::test::test_serialize::test_serialize
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<&mut rmp_serde::encode::FallibleWriter>>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<_>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<&mut rmp_serde::encode::FallibleWriter>>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut serde_json::ser::Serializer<&mut alloc::vec::Vec<u8>>>
+FN:93,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::expecting
+FN:50,<sk_core::k8s::gvk::GVK>::into_type_meta
+FN:62,<sk_core::k8s::gvk::GVK as core::ops::deref::Deref>::deref
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<&mut serde_yaml::de::DeserializerFromEvents>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<alloc::vec::Vec<u8>>>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:27,<sk_core::k8s::gvk::GVK>::new
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:146,sk_core::k8s::gvk::test::test_deserialize::test_deserialize
+FN:93,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::expecting
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::U8Deserializer<rmp_serde::decode::Error>>
+FN:38,<sk_core::k8s::gvk::GVK>::from_owner_ref
+FN:27,<sk_core::k8s::gvk::GVK>::new
+FN:31,<sk_core::k8s::gvk::GVK>::from_dynamic_obj
+FN:62,<sk_core::k8s::gvk::GVK as core::ops::deref::Deref>::deref
+FN:50,<sk_core::k8s::gvk::GVK>::into_type_meta
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:138,sk_core::k8s::gvk::test::test_serialize
+FN:146,sk_core::k8s::gvk::test::test_deserialize::test_deserialize
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::StrDeserializer<serde::de::value::Error>>
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<rmp_serde::bytes::OnlyBytes>
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<_>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<serde_json::error::Error>>
+FN:138,sk_core::k8s::gvk::test::test_serialize
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<&mut rmp_serde::encode::FallibleWriter>>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<rmp_serde::bytes::OnlyBytes>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::StrDeserializer<serde::de::value::Error>>
+FN:38,<sk_core::k8s::gvk::GVK>::from_owner_ref
+FN:93,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::expecting
+FN:146,sk_core::k8s::gvk::test::test_deserialize
+FN:138,sk_core::k8s::gvk::test::test_serialize::test_serialize
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<alloc::vec::Vec<u8>>>
+FN:79,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<alloc::vec::Vec<u8>>>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::U8Deserializer<rmp_serde::decode::Error>>
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:146,sk_core::k8s::gvk::test::test_deserialize
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<serde_json::error::Error>>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<rmp_serde::decode::Error>>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<rmp_serde::decode::Error>>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<serde_json::error::Error>>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<rmp_serde::decode::Error>>
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde_yaml::error::Error>
+FN:31,<sk_core::k8s::gvk::GVK>::from_dynamic_obj
+FN:97,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde::de::value::Error>
+FN:118,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<_>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::U8Deserializer<rmp_serde::decode::Error>>
+FNDA:0,<sk_core::k8s::gvk::GVK>::from_owner_ref
+FNDA:0,<sk_core::k8s::gvk::GVK>::into_type_meta
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<rmp_serde::bytes::OnlyBytes>
+FNDA:1,<sk_core::k8s::gvk::GVK>::new
+FNDA:1,<sk_core::k8s::gvk::GVK as core::ops::deref::Deref>::deref
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut serde_json::ser::Serializer<&mut alloc::vec::Vec<u8>>>
+FNDA:0,<sk_core::k8s::gvk::GVK as core::fmt::Display>::fmt
+FNDA:1,<sk_core::k8s::gvk::GVK>::from_dynamic_obj
+FNDA:1,<sk_core::k8s::gvk::GVK as core::fmt::Display>::fmt
+FNDA:1,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde::de::value::Error>
+FNDA:1,<sk_core::k8s::gvk::GVK as core::fmt::Display>::fmt
+FNDA:1,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,sk_core::k8s::gvk::test::test_serialize::test_serialize
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<&mut rmp_serde::encode::FallibleWriter>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<_>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<&mut rmp_serde::encode::FallibleWriter>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut serde_json::ser::Serializer<&mut alloc::vec::Vec<u8>>>
+FNDA:0,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_core::k8s::gvk::GVK>::into_type_meta
+FNDA:1,<sk_core::k8s::gvk::GVK as core::ops::deref::Deref>::deref
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<&mut serde_yaml::de::DeserializerFromEvents>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<alloc::vec::Vec<u8>>>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<sk_core::k8s::gvk::GVK>::new
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,sk_core::k8s::gvk::test::test_deserialize::test_deserialize
+FNDA:0,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::U8Deserializer<rmp_serde::decode::Error>>
+FNDA:1,<sk_core::k8s::gvk::GVK>::from_owner_ref
+FNDA:0,<sk_core::k8s::gvk::GVK>::new
+FNDA:0,<sk_core::k8s::gvk::GVK>::from_dynamic_obj
+FNDA:0,<sk_core::k8s::gvk::GVK as core::ops::deref::Deref>::deref
+FNDA:1,<sk_core::k8s::gvk::GVK>::into_type_meta
+FNDA:1,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,sk_core::k8s::gvk::test::test_serialize
+FNDA:0,sk_core::k8s::gvk::test::test_deserialize::test_deserialize
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::StrDeserializer<serde::de::value::Error>>
+FNDA:0,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<rmp_serde::bytes::OnlyBytes>
+FNDA:0,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<_>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<serde_json::error::Error>>
+FNDA:1,sk_core::k8s::gvk::test::test_serialize
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<&mut rmp_serde::encode::FallibleWriter>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<rmp_serde::bytes::OnlyBytes>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::StrDeserializer<serde::de::value::Error>>
+FNDA:1,<sk_core::k8s::gvk::GVK>::from_owner_ref
+FNDA:0,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::expecting
+FNDA:0,sk_core::k8s::gvk::test::test_deserialize
+FNDA:1,sk_core::k8s::gvk::test::test_serialize::test_serialize
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<alloc::vec::Vec<u8>>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::ser::Serialize>::serialize::<&mut rmp_serde::encode::Serializer<alloc::vec::Vec<u8>>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::de::value::U8Deserializer<rmp_serde::decode::Error>>
+FNDA:1,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:1,sk_core::k8s::gvk::test::test_deserialize
+FNDA:1,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<serde_json::error::Error>>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<rmp_serde::decode::Error>>
+FNDA:1,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<rmp_serde::decode::Error>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<serde_json::error::Error>>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<serde::__private::de::content::ContentRefDeserializer<rmp_serde::decode::Error>>
+FNDA:0,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde_yaml::error::Error>
+FNDA:0,<sk_core::k8s::gvk::GVK>::from_dynamic_obj
+FNDA:0,<sk_core::k8s::gvk::GVKVisitor as serde::de::Visitor>::visit_str::<serde::de::value::Error>
+FNDA:0,<sk_core::k8s::gvk::GVK as serde::de::Deserialize>::deserialize::<_>
+FNF:70
+FNH:31
+BRF:0
+BRH:0
+DA:27,54
+DA:28,54
+DA:29,54
+DA:31,1057
+DA:32,1057
+DA:33,1057
+DA:34,0
+DA:36,1057
+DA:38,58
+DA:39,58
+DA:40,58
+DA:41,58
+DA:42,14
+DA:43,44
+DA:44,44
+DA:46,0
+DA:48,58
+DA:50,49
+DA:51,49
+DA:52,49
+DA:53,49
+DA:54,49
+DA:55,49
+DA:62,1073
+DA:63,1073
+DA:64,1073
+DA:68,338
+DA:69,338
+DA:70,338
+DA:71,337
+DA:72,337
+DA:74,338
+DA:75,338
+DA:79,20
+DA:80,20
+DA:81,20
+DA:82,20
+DA:83,20
+DA:84,20
+DA:85,20
+DA:93,0
+DA:94,0
+DA:95,0
+DA:97,47
+DA:98,47
+DA:99,47
+DA:100,47
+DA:101,47
+DA:102,47
+DA:103,44
+DA:104,2
+DA:105,1
+DA:107,46
+DA:108,46
+DA:109,45
+DA:110,1
+DA:113,45
+DA:114,47
+DA:118,47
+DA:119,47
+DA:120,47
+DA:121,47
+DA:122,47
+DA:123,47
+LF:64
+LH:59
+end_of_record
+SF:sk-cli/src/validation/rules/status_field_populated.rs
+FN:59,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::reset
+FN:50,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}::{closure#0}
+FN:44,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}
+FN:59,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::reset
+FN:44,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}
+FN:38,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event
+FN:62,skctl::validation::rules::status_field_populated::validator
+FN:38,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event
+FN:62,skctl::validation::rules::status_field_populated::validator
+FN:50,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}::{closure#0}
+FNDA:0,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::reset
+FNDA:1,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}::{closure#0}
+FNDA:0,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}
+FNDA:0,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::reset
+FNDA:1,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}
+FNDA:0,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event
+FNDA:1,skctl::validation::rules::status_field_populated::validator
+FNDA:1,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event
+FNDA:0,skctl::validation::rules::status_field_populated::validator
+FNDA:0,<skctl::validation::rules::status_field_populated::StatusFieldPopulated as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}::{closure#0}
+FNF:10
+FNH:4
+BRF:0
+BRH:0
+DA:38,2
+DA:39,2
+DA:40,2
+DA:41,2
+DA:42,2
+DA:43,2
+DA:44,2
+DA:45,2
+DA:46,2
+DA:47,2
+DA:48,2
+DA:49,2
+DA:50,2
+DA:52,1
+DA:53,1
+DA:54,1
+DA:55,2
+DA:56,2
+DA:57,2
+DA:59,0
+DA:62,2
+DA:63,2
+DA:64,2
+DA:65,2
+DA:66,2
+DA:67,2
+DA:68,2
+DA:69,2
+LF:28
+LH:27
+end_of_record
+SF:sk-store/src/store.rs
+FN:330,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts::{closure#0}
+FN:61,<sk_store::store::TraceStore>::new
+FN:61,<sk_store::store::TraceStore>::new
+FN:326,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts::{closure#0}
+FN:329,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts
+FN:148,<sk_store::store::TraceStore>::collect_events
+FN:111,<sk_store::store::TraceStore>::from_exported_trace
+FN:268,<sk_store::store::TraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FN:103,<sk_store::store::TraceStore>::import
+FN:330,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts::{closure#0}
+FN:268,<sk_store::store::TraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FN:215,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj
+FN:317,<sk_store::store::TraceStore as sk_store::TraceStorable>::config
+FN:251,<sk_store::store::TraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FN:96,<sk_store::store::TraceStore>::export_all
+FN:321,<sk_store::store::TraceStore as sk_store::TraceStorable>::has_obj
+FN:71,<sk_store::store::TraceStore>::export
+FN:237,<sk_store::store::TraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FN:61,<sk_store::store::TraceStore>::new
+FN:329,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts
+FN:71,<sk_store::store::TraceStore>::export
+FN:65,<sk_store::store::TraceStore>::clone_with_events
+FN:215,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj
+FN:317,<sk_store::store::TraceStore as sk_store::TraceStorable>::config
+FN:65,<sk_store::store::TraceStore>::clone_with_events
+FN:148,<sk_store::store::TraceStore>::collect_events
+FN:325,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts
+FN:103,<sk_store::store::TraceStore>::import
+FN:148,<sk_store::store::TraceStore>::collect_events
+FN:131,<sk_store::store::TraceStore>::from_exported_trace::{closure#0}
+FN:333,<sk_store::store::TraceStore as sk_store::TraceStorable>::iter
+FN:229,<sk_store::store::TraceStore as sk_store::TraceStorable>::delete_obj
+FN:343,<sk_store::TraceIterator as core::iter::traits::iterator::Iterator>::next
+FN:96,<sk_store::store::TraceStore>::export_all
+FN:343,<sk_store::TraceIterator as core::iter::traits::iterator::Iterator>::next
+FN:251,<sk_store::store::TraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FN:215,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj
+FN:131,<sk_store::store::TraceStore>::from_exported_trace::{closure#0}
+FN:343,<sk_store::TraceIterator as core::iter::traits::iterator::Iterator>::next
+FN:220,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj::{closure#0}
+FN:321,<sk_store::store::TraceStore as sk_store::TraceStorable>::has_obj
+FN:96,<sk_store::store::TraceStore>::export_all
+FN:251,<sk_store::store::TraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FN:364,<sk_store::store::TraceStore>::sorted_objs_at
+FN:321,<sk_store::store::TraceStore as sk_store::TraceStorable>::has_obj
+FN:131,<sk_store::store::TraceStore>::from_exported_trace::{closure#0}
+FN:65,<sk_store::store::TraceStore>::clone_with_events
+FN:268,<sk_store::store::TraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FN:325,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts
+FN:333,<sk_store::store::TraceStore as sk_store::TraceStorable>::iter
+FN:220,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj::{closure#0}
+FN:317,<sk_store::store::TraceStore as sk_store::TraceStorable>::config
+FN:237,<sk_store::store::TraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FN:111,<sk_store::store::TraceStore>::from_exported_trace
+FN:229,<sk_store::store::TraceStore as sk_store::TraceStorable>::delete_obj
+FN:103,<sk_store::store::TraceStore>::import
+FN:111,<sk_store::store::TraceStore>::from_exported_trace
+FN:326,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts::{closure#0}
+FN:71,<sk_store::store::TraceStore>::export
+FN:326,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts::{closure#0}
+FN:237,<sk_store::store::TraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FN:229,<sk_store::store::TraceStore as sk_store::TraceStorable>::delete_obj
+FN:329,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts
+FN:220,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj::{closure#0}
+FN:364,<sk_store::store::TraceStore>::sorted_objs_at
+FN:333,<sk_store::store::TraceStore as sk_store::TraceStorable>::iter
+FN:330,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts::{closure#0}
+FN:325,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts::{closure#0}
+FNDA:1,<sk_store::store::TraceStore>::new
+FNDA:1,<sk_store::store::TraceStore>::new
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts::{closure#0}
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts
+FNDA:0,<sk_store::store::TraceStore>::collect_events
+FNDA:1,<sk_store::store::TraceStore>::from_exported_trace
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FNDA:1,<sk_store::store::TraceStore>::import
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts::{closure#0}
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::config
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FNDA:0,<sk_store::store::TraceStore>::export_all
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::has_obj
+FNDA:1,<sk_store::store::TraceStore>::export
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FNDA:0,<sk_store::store::TraceStore>::new
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts
+FNDA:0,<sk_store::store::TraceStore>::export
+FNDA:0,<sk_store::store::TraceStore>::clone_with_events
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::config
+FNDA:0,<sk_store::store::TraceStore>::clone_with_events
+FNDA:1,<sk_store::store::TraceStore>::collect_events
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts
+FNDA:1,<sk_store::store::TraceStore>::import
+FNDA:1,<sk_store::store::TraceStore>::collect_events
+FNDA:1,<sk_store::store::TraceStore>::from_exported_trace::{closure#0}
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::iter
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::delete_obj
+FNDA:1,<sk_store::TraceIterator as core::iter::traits::iterator::Iterator>::next
+FNDA:0,<sk_store::store::TraceStore>::export_all
+FNDA:1,<sk_store::TraceIterator as core::iter::traits::iterator::Iterator>::next
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj
+FNDA:0,<sk_store::store::TraceStore>::from_exported_trace::{closure#0}
+FNDA:0,<sk_store::TraceIterator as core::iter::traits::iterator::Iterator>::next
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj::{closure#0}
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::has_obj
+FNDA:0,<sk_store::store::TraceStore>::export_all
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FNDA:0,<sk_store::store::TraceStore>::sorted_objs_at
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::has_obj
+FNDA:0,<sk_store::store::TraceStore>::from_exported_trace::{closure#0}
+FNDA:0,<sk_store::store::TraceStore>::clone_with_events
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::iter
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj::{closure#0}
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::config
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FNDA:1,<sk_store::store::TraceStore>::from_exported_trace
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::delete_obj
+FNDA:0,<sk_store::store::TraceStore>::import
+FNDA:0,<sk_store::store::TraceStore>::from_exported_trace
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts::{closure#0}
+FNDA:1,<sk_store::store::TraceStore>::export
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts::{closure#0}
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::delete_obj
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::create_or_update_obj::{closure#0}
+FNDA:1,<sk_store::store::TraceStore>::sorted_objs_at
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::iter
+FNDA:0,<sk_store::store::TraceStore as sk_store::TraceStorable>::end_ts::{closure#0}
+FNDA:1,<sk_store::store::TraceStore as sk_store::TraceStorable>::start_ts
+FNF:68
+FNH:28
+BRF:0
+BRH:0
+DA:61,41
+DA:62,41
+DA:63,41
+DA:65,0
+DA:66,0
+DA:67,0
+DA:68,0
+DA:69,0
+DA:71,10
+DA:72,10
+DA:78,10
+DA:79,10
+DA:80,10
+DA:81,10
+DA:82,10
+DA:83,10
+DA:84,10
+DA:85,10
+DA:86,10
+DA:87,10
+DA:88,10
+DA:89,10
+DA:90,10
+DA:92,10
+DA:93,10
+DA:94,10
+DA:96,0
+DA:97,0
+DA:98,0
+DA:100,0
+DA:101,0
+DA:103,10
+DA:104,10
+DA:105,10
+DA:106,10
+DA:111,10
+DA:112,10
+DA:113,10
+DA:114,10
+DA:115,10
+DA:116,0
+DA:117,10
+DA:118,10
+DA:119,10
+DA:120,10
+DA:121,10
+DA:122,10
+DA:123,10
+DA:124,10
+DA:125,10
+DA:126,10
+DA:127,10
+DA:128,10
+DA:129,10
+DA:130,1
+DA:131,3
+DA:132,1
+DA:133,1
+DA:134,1
+DA:135,1
+DA:136,1
+DA:137,9
+DA:139,10
+DA:140,10
+DA:141,10
+DA:142,10
+DA:143,10
+DA:144,10
+DA:145,10
+DA:146,10
+DA:148,16
+DA:149,16
+DA:150,16
+DA:151,16
+DA:152,16
+DA:153,16
+DA:154,16
+DA:155,16
+DA:156,16
+DA:157,16
+DA:158,16
+DA:159,16
+DA:160,16
+DA:161,16
+DA:162,16
+DA:163,16
+DA:165,40
+DA:169,32
+DA:170,2
+DA:171,30
+DA:173,30
+DA:174,87
+DA:175,61
+DA:176,61
+DA:177,61
+DA:178,21
+DA:179,40
+DA:180,61
+DA:181,61
+DA:184,43
+DA:185,17
+DA:186,17
+DA:187,17
+DA:188,2
+DA:189,15
+DA:190,17
+DA:191,10
+DA:192,10
+DA:195,26
+DA:196,21
+DA:197,21
+DA:198,4
+DA:203,16
+DA:204,16
+DA:205,16
+DA:215,50
+DA:216,50
+DA:218,50
+DA:219,50
+DA:220,50
+DA:221,50
+DA:222,50
+DA:223,39
+DA:224,39
+DA:225,50
+DA:226,50
+DA:227,50
+DA:229,8
+DA:230,8
+DA:231,8
+DA:232,8
+DA:233,8
+DA:234,8
+DA:235,8
+DA:237,10
+DA:238,10
+DA:239,54
+DA:240,44
+DA:241,44
+DA:242,44
+DA:245,10
+DA:246,1
+DA:248,10
+DA:249,10
+DA:251,3
+DA:252,3
+DA:253,3
+DA:254,3
+DA:255,3
+DA:256,3
+DA:257,3
+DA:258,3
+DA:259,3
+DA:260,1
+DA:261,2
+DA:263,3
+DA:268,7
+DA:269,7
+DA:270,7
+DA:271,7
+DA:272,7
+DA:273,7
+DA:274,7
+DA:275,7
+DA:276,7
+DA:277,7
+DA:278,7
+DA:279,7
+DA:280,7
+DA:281,2
+DA:282,5
+DA:284,6
+DA:286,4
+DA:287,4
+DA:288,4
+DA:289,1
+DA:290,3
+DA:291,3
+DA:292,3
+DA:293,1
+DA:294,2
+DA:305,2
+DA:306,2
+DA:307,2
+DA:308,2
+DA:311,1
+DA:314,6
+DA:315,7
+DA:317,3696
+DA:318,3696
+DA:319,3696
+DA:321,4
+DA:322,4
+DA:323,4
+DA:325,8
+DA:326,8
+DA:327,8
+DA:329,8
+DA:330,8
+DA:331,8
+DA:333,24
+DA:334,24
+DA:335,24
+DA:343,66
+DA:344,66
+DA:345,8
+DA:346,58
+DA:348,58
+DA:349,58
+DA:350,28
+DA:351,14
+DA:354,58
+DA:355,58
+DA:356,66
+LF:214
+LH:203
+end_of_record
+SF:sk-cli/src/completions.rs
+FN:48,skctl::completions::completion_filename_for
+FN:122,skctl::completions::test::test_prompt_for_location::case_3_no_entry
+FN:122,skctl::completions::test::test_prompt_for_location::case_1_abs_path
+FN:29,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:59,skctl::completions::prompt_for_location::<&[u8]>
+FN:122,skctl::completions::test::test_prompt_for_location::case_1_abs_path
+FN:32,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:122,skctl::completions::test::test_prompt_for_location
+FN:131,skctl::completions::test::test_prompt_for_location_unsupported
+FN:81,skctl::completions::print_extra_info
+FN:29,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:32,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:122,skctl::completions::test::test_prompt_for_location::case_2_home_dir
+FN:122,skctl::completions::test::test_prompt_for_location
+FN:59,skctl::completions::prompt_for_location::<&[u8]>
+FN:48,skctl::completions::completion_filename_for
+FN:122,skctl::completions::test::test_prompt_for_location::case_3_no_entry
+FN:131,skctl::completions::test::test_prompt_for_location_unsupported::test_prompt_for_location_unsupported
+FN:29,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:29,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:35,skctl::completions::default_path_for
+FN:131,skctl::completions::test::test_prompt_for_location_unsupported
+FN:35,skctl::completions::default_path_for
+FN:81,skctl::completions::print_extra_info
+FN:32,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:95,skctl::completions::cmd
+FN:95,skctl::completions::cmd
+FN:131,skctl::completions::test::test_prompt_for_location_unsupported::test_prompt_for_location_unsupported
+FN:32,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:122,skctl::completions::test::test_prompt_for_location::case_2_home_dir
+FNDA:0,skctl::completions::completion_filename_for
+FNDA:0,skctl::completions::test::test_prompt_for_location::case_3_no_entry
+FNDA:0,skctl::completions::test::test_prompt_for_location::case_1_abs_path
+FNDA:0,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::completions::prompt_for_location::<&[u8]>
+FNDA:1,skctl::completions::test::test_prompt_for_location::case_1_abs_path
+FNDA:0,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:1,skctl::completions::test::test_prompt_for_location
+FNDA:1,skctl::completions::test::test_prompt_for_location_unsupported
+FNDA:0,skctl::completions::print_extra_info
+FNDA:0,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:1,skctl::completions::test::test_prompt_for_location::case_2_home_dir
+FNDA:0,skctl::completions::test::test_prompt_for_location
+FNDA:1,skctl::completions::prompt_for_location::<&[u8]>
+FNDA:1,skctl::completions::completion_filename_for
+FNDA:1,skctl::completions::test::test_prompt_for_location::case_3_no_entry
+FNDA:1,skctl::completions::test::test_prompt_for_location_unsupported::test_prompt_for_location_unsupported
+FNDA:0,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::completions::default_path_for
+FNDA:0,skctl::completions::test::test_prompt_for_location_unsupported
+FNDA:1,skctl::completions::default_path_for
+FNDA:0,skctl::completions::print_extra_info
+FNDA:0,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,skctl::completions::cmd
+FNDA:0,skctl::completions::cmd
+FNDA:0,skctl::completions::test::test_prompt_for_location_unsupported::test_prompt_for_location_unsupported
+FNDA:0,<skctl::completions::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,skctl::completions::test::test_prompt_for_location::case_2_home_dir
+FNF:30
+FNH:9
+BRF:0
+BRH:0
+DA:29,0
+DA:32,0
+DA:35,5
+DA:36,5
+DA:37,5
+DA:38,5
+DA:39,0
+DA:40,0
+DA:41,0
+DA:42,0
+DA:43,0
+DA:45,5
+DA:46,5
+DA:48,3
+DA:49,3
+DA:50,3
+DA:51,0
+DA:52,0
+DA:53,0
+DA:54,0
+DA:55,0
+DA:57,3
+DA:59,4
+DA:60,4
+DA:61,4
+DA:63,4
+DA:64,4
+DA:65,1
+DA:66,3
+DA:67,2
+DA:68,2
+DA:69,2
+DA:70,1
+DA:71,1
+DA:72,1
+DA:74,1
+DA:77,3
+DA:78,3
+DA:79,4
+DA:81,0
+DA:82,0
+DA:83,0
+DA:84,0
+DA:86,0
+DA:87,0
+DA:88,0
+DA:89,0
+DA:91,0
+DA:93,0
+DA:95,0
+DA:96,0
+DA:97,0
+DA:99,0
+DA:100,0
+DA:101,0
+DA:104,0
+DA:106,0
+DA:107,0
+DA:108,0
+DA:109,0
+DA:110,0
+DA:112,0
+DA:113,0
+LF:63
+LH:27
+end_of_record
+SF:sk-driver/src/runner.rs
+FN:176,sk_driver::runner::cleanup_trace::{closure#0}
+FN:171,sk_driver::runner::cleanup_trace
+FN:48,sk_driver::runner::build_virtual_ns
+FN:95,sk_driver::runner::run_trace::{closure#0}::{closure#0}
+FN:59,sk_driver::runner::build_virtual_obj
+FN:95,sk_driver::runner::run_trace::{closure#0}
+FNDA:1,sk_driver::runner::cleanup_trace::{closure#0}
+FNDA:1,sk_driver::runner::cleanup_trace
+FNDA:1,sk_driver::runner::build_virtual_ns
+FNDA:1,sk_driver::runner::run_trace::{closure#0}::{closure#0}
+FNDA:1,sk_driver::runner::build_virtual_obj
+FNDA:1,sk_driver::runner::run_trace::{closure#0}
+FNF:6
+FNH:6
+BRF:0
+BRH:0
+DA:48,4
+DA:49,4
+DA:50,4
+DA:51,4
+DA:52,4
+DA:53,4
+DA:54,4
+DA:55,4
+DA:56,4
+DA:57,4
+DA:59,2
+DA:60,2
+DA:61,2
+DA:62,2
+DA:63,2
+DA:64,2
+DA:65,2
+DA:66,2
+DA:67,2
+DA:68,2
+DA:69,2
+DA:70,2
+DA:71,2
+DA:73,2
+DA:74,2
+DA:75,2
+DA:76,2
+DA:77,2
+DA:78,2
+DA:79,2
+DA:80,2
+DA:81,2
+DA:89,2
+DA:90,0
+DA:92,2
+DA:93,2
+DA:95,4
+DA:171,5
+DA:172,5
+DA:173,5
+DA:174,5
+DA:175,5
+DA:176,5
+DA:177,5
+DA:179,5
+DA:180,5
+DA:183,4
+DA:184,4
+DA:185,4
+DA:186,4
+DA:187,4
+DA:188,4
+DA:189,4
+DA:190,4
+DA:191,12
+DA:196,3
+DA:197,3
+DA:199,1
+DA:200,1
+DA:201,1
+DA:203,0
+DA:206,4
+DA:207,1
+DA:208,3
+DA:209,3
+DA:210,3
+DA:211,5
+LF:67
+LH:65
+end_of_record
+SF:sk-core/src/time.rs
+FN:14,sk_core::time::duration_to_ts_from
+FN:10,sk_core::time::duration_to_ts
+FN:10,sk_core::time::duration_to_ts
+FN:10,sk_core::time::duration_to_ts
+FN:14,sk_core::time::duration_to_ts_from
+FN:14,sk_core::time::duration_to_ts_from
+FNDA:0,sk_core::time::duration_to_ts_from
+FNDA:0,sk_core::time::duration_to_ts
+FNDA:0,sk_core::time::duration_to_ts
+FNDA:0,sk_core::time::duration_to_ts
+FNDA:0,sk_core::time::duration_to_ts_from
+FNDA:1,sk_core::time::duration_to_ts_from
+FNF:6
+FNH:1
+BRF:0
+BRH:0
+DA:10,0
+DA:11,0
+DA:12,0
+DA:14,7
+DA:15,7
+DA:16,7
+DA:17,7
+LF:7
+LH:4
+end_of_record
+SF:sk-ctrl/src/objects.rs
+FN:76,sk_ctrl::objects::build_prometheus::{closure#0}
+FN:82,sk_ctrl::objects::build_prometheus::{closure#1}
+FN:302,sk_ctrl::objects::build_local_trace_volume
+FN:85,sk_ctrl::objects::build_prometheus::{closure#2}
+FN:311,sk_ctrl::objects::build_local_trace_volume::{closure#0}
+FN:203,sk_ctrl::objects::build_driver_job::{closure#0}::{closure#0}
+FN:42,sk_ctrl::objects::build_driver_namespace
+FN:50,sk_ctrl::objects::build_prometheus
+FN:180,sk_ctrl::objects::build_driver_job
+FN:317,sk_ctrl::objects::build_local_trace_volume::{closure#1}
+FN:91,sk_ctrl::objects::build_prometheus::{closure#3}
+FN:163,sk_ctrl::objects::build_driver_service
+FN:258,sk_ctrl::objects::build_driver_args
+FN:200,sk_ctrl::objects::build_driver_job::{closure#0}
+FN:121,sk_ctrl::objects::build_mutating_webhook
+FN:282,sk_ctrl::objects::build_certificate_volumes
+FNDA:0,sk_ctrl::objects::build_prometheus::{closure#0}
+FNDA:0,sk_ctrl::objects::build_prometheus::{closure#1}
+FNDA:1,sk_ctrl::objects::build_local_trace_volume
+FNDA:0,sk_ctrl::objects::build_prometheus::{closure#2}
+FNDA:0,sk_ctrl::objects::build_local_trace_volume::{closure#0}
+FNDA:0,sk_ctrl::objects::build_driver_job::{closure#0}::{closure#0}
+FNDA:1,sk_ctrl::objects::build_driver_namespace
+FNDA:1,sk_ctrl::objects::build_prometheus
+FNDA:1,sk_ctrl::objects::build_driver_job
+FNDA:0,sk_ctrl::objects::build_local_trace_volume::{closure#1}
+FNDA:0,sk_ctrl::objects::build_prometheus::{closure#3}
+FNDA:1,sk_ctrl::objects::build_driver_service
+FNDA:1,sk_ctrl::objects::build_driver_args
+FNDA:0,sk_ctrl::objects::build_driver_job::{closure#0}
+FNDA:1,sk_ctrl::objects::build_mutating_webhook
+FNDA:1,sk_ctrl::objects::build_certificate_volumes
+FNF:16
+FNH:8
+BRF:0
+BRH:0
+DA:42,5
+DA:43,5
+DA:44,5
+DA:45,5
+DA:46,5
+DA:47,5
+DA:48,5
+DA:50,4
+DA:51,4
+DA:52,4
+DA:53,4
+DA:54,4
+DA:55,4
+DA:56,4
+DA:57,4
+DA:58,4
+DA:59,4
+DA:60,0
+DA:61,0
+DA:62,0
+DA:63,0
+DA:64,0
+DA:65,0
+DA:66,0
+DA:67,0
+DA:68,0
+DA:69,0
+DA:70,0
+DA:71,0
+DA:74,4
+DA:75,4
+DA:76,4
+DA:77,0
+DA:78,4
+DA:79,4
+DA:80,4
+DA:81,4
+DA:82,4
+DA:83,4
+DA:84,4
+DA:85,4
+DA:86,0
+DA:87,4
+DA:88,4
+DA:89,4
+DA:90,4
+DA:91,4
+DA:92,4
+DA:93,4
+DA:94,4
+DA:95,4
+DA:96,4
+DA:97,4
+DA:98,4
+DA:99,4
+DA:100,4
+DA:101,4
+DA:102,4
+DA:103,4
+DA:104,4
+DA:105,4
+DA:106,4
+DA:107,4
+DA:108,4
+DA:109,4
+DA:110,4
+DA:111,4
+DA:112,4
+DA:113,4
+DA:114,4
+DA:115,4
+DA:116,4
+DA:117,4
+DA:118,4
+DA:119,4
+DA:121,5
+DA:122,5
+DA:123,5
+DA:124,5
+DA:125,5
+DA:126,5
+DA:127,5
+DA:128,5
+DA:129,0
+DA:130,0
+DA:131,0
+DA:132,0
+DA:133,5
+DA:135,5
+DA:136,5
+DA:137,5
+DA:138,5
+DA:139,5
+DA:140,5
+DA:141,5
+DA:142,5
+DA:143,5
+DA:144,5
+DA:145,5
+DA:146,5
+DA:147,5
+DA:148,5
+DA:149,5
+DA:150,5
+DA:151,5
+DA:152,5
+DA:153,5
+DA:154,5
+DA:155,5
+DA:156,5
+DA:157,5
+DA:158,5
+DA:159,5
+DA:160,5
+DA:161,5
+DA:163,5
+DA:164,5
+DA:165,5
+DA:166,5
+DA:167,5
+DA:168,5
+DA:169,5
+DA:170,5
+DA:171,5
+DA:172,5
+DA:173,5
+DA:174,5
+DA:175,5
+DA:176,5
+DA:177,5
+DA:178,5
+DA:180,5
+DA:181,5
+DA:182,5
+DA:183,5
+DA:184,5
+DA:185,5
+DA:186,5
+DA:187,5
+DA:188,5
+DA:190,5
+DA:191,5
+DA:192,5
+DA:193,5
+DA:194,5
+DA:196,0
+DA:198,5
+DA:200,5
+DA:201,0
+DA:202,0
+DA:203,0
+DA:204,0
+DA:205,0
+DA:206,0
+DA:207,0
+DA:208,5
+DA:209,5
+DA:210,5
+DA:211,5
+DA:212,5
+DA:213,5
+DA:214,5
+DA:215,5
+DA:216,5
+DA:217,5
+DA:218,5
+DA:219,5
+DA:220,5
+DA:221,5
+DA:222,5
+DA:223,5
+DA:224,5
+DA:225,5
+DA:226,5
+DA:227,5
+DA:228,5
+DA:229,5
+DA:230,5
+DA:231,5
+DA:232,5
+DA:233,5
+DA:234,5
+DA:235,5
+DA:236,5
+DA:237,5
+DA:238,5
+DA:239,5
+DA:240,5
+DA:241,5
+DA:242,5
+DA:243,5
+DA:244,5
+DA:245,5
+DA:246,5
+DA:247,5
+DA:248,5
+DA:249,5
+DA:250,5
+DA:251,5
+DA:252,5
+DA:253,5
+DA:254,5
+DA:255,5
+DA:256,5
+DA:258,5
+DA:259,5
+DA:260,5
+DA:261,5
+DA:262,5
+DA:263,5
+DA:264,5
+DA:265,5
+DA:266,5
+DA:267,5
+DA:268,5
+DA:269,5
+DA:270,5
+DA:271,5
+DA:272,5
+DA:273,5
+DA:274,5
+DA:275,5
+DA:276,5
+DA:277,5
+DA:278,5
+DA:279,5
+DA:280,5
+DA:282,5
+DA:283,5
+DA:284,5
+DA:285,5
+DA:286,5
+DA:287,5
+DA:288,5
+DA:289,5
+DA:290,5
+DA:291,5
+DA:292,5
+DA:293,5
+DA:294,5
+DA:295,5
+DA:296,5
+DA:297,5
+DA:298,5
+DA:299,5
+DA:300,5
+DA:302,5
+DA:303,5
+DA:304,5
+DA:305,5
+DA:306,0
+DA:307,5
+DA:309,5
+DA:310,5
+DA:311,5
+DA:313,5
+DA:314,5
+DA:315,5
+DA:316,5
+DA:317,5
+DA:319,5
+DA:320,5
+DA:321,5
+DA:322,5
+DA:323,5
+DA:325,5
+DA:326,5
+DA:327,5
+DA:328,5
+DA:329,5
+DA:330,5
+DA:331,5
+DA:332,5
+DA:333,5
+DA:334,5
+DA:335,5
+DA:336,5
+DA:337,5
+DA:338,5
+LF:279
+LH:252
+end_of_record
+SF:sk-store/src/config.rs
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_yaml::de::DeserializerFromEvents>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:36,<sk_store::config::TracerConfig>::track_lifecycle_for::{closure#0}
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:35,<sk_store::config::TracerConfig>::track_lifecycle_for
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_yaml::de::MapAccess>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:27,<sk_store::config::TracerConfig>::load
+FN:31,<sk_store::config::TracerConfig>::pod_spec_template_path
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_yaml::error::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_yaml::de::MapAccess>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:36,<sk_store::config::TracerConfig>::track_lifecycle_for::{closure#0}
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut serde_yaml::de::MapAccess>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut serde_yaml::de::MapAccess>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_yaml::error::Error>
+FN:35,<sk_store::config::TracerConfig>::track_lifecycle_for
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:36,<sk_store::config::TracerConfig>::track_lifecycle_for::{closure#0}
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:27,<sk_store::config::TracerConfig>::load
+FN:31,<sk_store::config::TracerConfig>::pod_spec_template_path
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:35,<sk_store::config::TracerConfig>::track_lifecycle_for
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:31,<sk_store::config::TracerConfig>::pod_spec_template_path
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_yaml::de::DeserializerFromEvents>
+FN:11,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:20,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:27,<sk_store::config::TracerConfig>::load
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_yaml::de::DeserializerFromEvents>
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::config::TracerConfig>::track_lifecycle_for::{closure#0}
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::config::TracerConfig>::track_lifecycle_for
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_yaml::de::MapAccess>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::config::TracerConfig>::load
+FNDA:0,<sk_store::config::TracerConfig>::pod_spec_template_path
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_yaml::error::Error>
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_yaml::de::MapAccess>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<sk_store::config::TracerConfig>::track_lifecycle_for::{closure#0}
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut serde_yaml::de::MapAccess>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut serde_yaml::de::MapAccess>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_yaml::error::Error>
+FNDA:1,<sk_store::config::TracerConfig>::track_lifecycle_for
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:1,<sk_store::config::TracerConfig>::track_lifecycle_for::{closure#0}
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<sk_store::config::TracerConfig>::load
+FNDA:1,<sk_store::config::TracerConfig>::pod_spec_template_path
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:1,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:1,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::config::TracerConfig>::track_lifecycle_for
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::config::TracerConfig>::pod_spec_template_path
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_yaml::de::DeserializerFromEvents>
+FNDA:0,<<sk_store::config::TrackedObjectConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::config::TracerConfig as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::config::TracerConfig>::load
+FNF:98
+FNH:24
+BRF:0
+BRH:0
+DA:27,0
+DA:28,0
+DA:29,0
+DA:31,44
+DA:32,44
+DA:33,44
+DA:35,3
+DA:36,3
+DA:37,3
+LF:9
+LH:6
+end_of_record
+SF:sk-core/src/k8s/pod_lifecycle.rs
+FN:52,<sk_core::k8s::PodLifecycleData>::new_for::{closure#0}
+FN:38,<sk_core::k8s::PodLifecycleData>::new
+FN:97,<sk_core::k8s::PodLifecycleData>::overlaps
+FN:135,<sk_core::k8s::PodLifecycleData>::running
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some::case_1_both_none
+FN:218,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#1}
+FN:217,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#0}
+FN:215,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq
+FN:135,<sk_core::k8s::PodLifecycleData>::running
+FN:239,sk_core::k8s::pod_lifecycle::min_some::<i64>
+FN:239,sk_core::k8s::pod_lifecycle::min_some::<i32>
+FN:227,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#1}
+FN:82,<sk_core::k8s::PodLifecycleData>::end_ts
+FN:215,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq
+FN:97,<sk_core::k8s::PodLifecycleData>::overlaps
+FN:60,<sk_core::k8s::PodLifecycleData>::new_for::{closure#1}
+FN:215,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq
+FN:46,<sk_core::k8s::PodLifecycleData>::new_for
+FN:202,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#0}
+FN:60,<sk_core::k8s::PodLifecycleData>::new_for::{closure#1}
+FN:227,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#1}
+FN:217,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#0}
+FN:224,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some
+FN:46,<sk_core::k8s::PodLifecycleData>::new_for
+FN:46,<sk_core::k8s::PodLifecycleData>::new_for
+FN:224,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp
+FN:52,<sk_core::k8s::PodLifecycleData>::new_for::{closure#0}
+FN:135,<sk_core::k8s::PodLifecycleData>::running
+FN:89,<sk_core::k8s::PodLifecycleData>::start_ts
+FN:89,<sk_core::k8s::PodLifecycleData>::start_ts
+FN:206,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#1}
+FN:218,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#1}
+FN:227,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#1}
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some::case_3_right_some
+FN:239,sk_core::k8s::pod_lifecycle::min_some::<i32>
+FN:226,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#0}
+FN:108,<sk_core::k8s::PodLifecycleData>::guess_finished_lifecycle
+FN:201,sk_core::k8s::pod_lifecycle::get_start_end_ts
+FN:206,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#1}
+FN:97,<sk_core::k8s::PodLifecycleData>::overlaps
+FN:38,<sk_core::k8s::PodLifecycleData>::new
+FN:108,<sk_core::k8s::PodLifecycleData>::guess_finished_lifecycle
+FN:201,sk_core::k8s::pod_lifecycle::get_start_end_ts
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some::case_1_both_none
+FN:38,<sk_core::k8s::PodLifecycleData>::new
+FN:82,<sk_core::k8s::PodLifecycleData>::end_ts
+FN:160,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd>::partial_cmp
+FN:131,<sk_core::k8s::PodLifecycleData>::empty
+FN:160,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd>::partial_cmp
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some::case_3_right_some
+FN:226,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#0}
+FN:139,<sk_core::k8s::PodLifecycleData>::finished
+FN:52,<sk_core::k8s::PodLifecycleData>::new_for::{closure#0}
+FN:60,<sk_core::k8s::PodLifecycleData>::new_for::{closure#1}
+FN:108,<sk_core::k8s::PodLifecycleData>::guess_finished_lifecycle
+FN:217,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#0}
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some::case_4_both_some
+FN:224,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp
+FN:218,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#1}
+FN:239,sk_core::k8s::pod_lifecycle::min_some::<i64>
+FN:239,sk_core::k8s::pod_lifecycle::min_some::<i64>
+FN:201,sk_core::k8s::pod_lifecycle::get_start_end_ts
+FN:139,<sk_core::k8s::PodLifecycleData>::finished
+FN:202,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#0}
+FN:89,<sk_core::k8s::PodLifecycleData>::start_ts
+FN:131,<sk_core::k8s::PodLifecycleData>::empty
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some::case_4_both_some
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some::case_2_left_some
+FN:139,<sk_core::k8s::PodLifecycleData>::finished
+FN:131,<sk_core::k8s::PodLifecycleData>::empty
+FN:160,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd>::partial_cmp
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some::case_2_left_some
+FN:82,<sk_core::k8s::PodLifecycleData>::end_ts
+FN:226,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#0}
+FN:202,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#0}
+FN:206,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#1}
+FN:255,sk_core::k8s::pod_lifecycle::test::test_min_some
+FNDA:0,<sk_core::k8s::PodLifecycleData>::new_for::{closure#0}
+FNDA:1,<sk_core::k8s::PodLifecycleData>::new
+FNDA:1,<sk_core::k8s::PodLifecycleData>::overlaps
+FNDA:0,<sk_core::k8s::PodLifecycleData>::running
+FNDA:1,sk_core::k8s::pod_lifecycle::test::test_min_some::case_1_both_none
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#1}
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#0}
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq
+FNDA:0,<sk_core::k8s::PodLifecycleData>::running
+FNDA:1,sk_core::k8s::pod_lifecycle::min_some::<i64>
+FNDA:1,sk_core::k8s::pod_lifecycle::min_some::<i32>
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#1}
+FNDA:0,<sk_core::k8s::PodLifecycleData>::end_ts
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq
+FNDA:0,<sk_core::k8s::PodLifecycleData>::overlaps
+FNDA:1,<sk_core::k8s::PodLifecycleData>::new_for::{closure#1}
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq
+FNDA:1,<sk_core::k8s::PodLifecycleData>::new_for
+FNDA:0,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#0}
+FNDA:1,<sk_core::k8s::PodLifecycleData>::new_for::{closure#1}
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#1}
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#0}
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp
+FNDA:0,sk_core::k8s::pod_lifecycle::test::test_min_some
+FNDA:0,<sk_core::k8s::PodLifecycleData>::new_for
+FNDA:1,<sk_core::k8s::PodLifecycleData>::new_for
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp
+FNDA:0,<sk_core::k8s::PodLifecycleData>::new_for::{closure#0}
+FNDA:0,<sk_core::k8s::PodLifecycleData>::running
+FNDA:0,<sk_core::k8s::PodLifecycleData>::start_ts
+FNDA:1,<sk_core::k8s::PodLifecycleData>::start_ts
+FNDA:0,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#1}
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#1}
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#1}
+FNDA:0,sk_core::k8s::pod_lifecycle::test::test_min_some::case_3_right_some
+FNDA:0,sk_core::k8s::pod_lifecycle::min_some::<i32>
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#0}
+FNDA:1,<sk_core::k8s::PodLifecycleData>::guess_finished_lifecycle
+FNDA:0,sk_core::k8s::pod_lifecycle::get_start_end_ts
+FNDA:0,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#1}
+FNDA:0,<sk_core::k8s::PodLifecycleData>::overlaps
+FNDA:1,<sk_core::k8s::PodLifecycleData>::new
+FNDA:0,<sk_core::k8s::PodLifecycleData>::guess_finished_lifecycle
+FNDA:1,sk_core::k8s::pod_lifecycle::get_start_end_ts
+FNDA:0,sk_core::k8s::pod_lifecycle::test::test_min_some::case_1_both_none
+FNDA:0,<sk_core::k8s::PodLifecycleData>::new
+FNDA:0,<sk_core::k8s::PodLifecycleData>::end_ts
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd>::partial_cmp
+FNDA:0,<sk_core::k8s::PodLifecycleData>::empty
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd>::partial_cmp
+FNDA:1,sk_core::k8s::pod_lifecycle::test::test_min_some::case_3_right_some
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#0}
+FNDA:1,<sk_core::k8s::PodLifecycleData>::finished
+FNDA:1,<sk_core::k8s::PodLifecycleData>::new_for::{closure#0}
+FNDA:0,<sk_core::k8s::PodLifecycleData>::new_for::{closure#1}
+FNDA:0,<sk_core::k8s::PodLifecycleData>::guess_finished_lifecycle
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#0}
+FNDA:0,sk_core::k8s::pod_lifecycle::test::test_min_some::case_4_both_some
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::eq::{closure#1}
+FNDA:0,sk_core::k8s::pod_lifecycle::min_some::<i64>
+FNDA:1,sk_core::k8s::pod_lifecycle::min_some::<i64>
+FNDA:1,sk_core::k8s::pod_lifecycle::get_start_end_ts
+FNDA:0,<sk_core::k8s::PodLifecycleData>::finished
+FNDA:0,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#0}
+FNDA:0,<sk_core::k8s::PodLifecycleData>::start_ts
+FNDA:1,<sk_core::k8s::PodLifecycleData>::empty
+FNDA:1,sk_core::k8s::pod_lifecycle::test::test_min_some::case_4_both_some
+FNDA:1,sk_core::k8s::pod_lifecycle::test::test_min_some::case_2_left_some
+FNDA:0,<sk_core::k8s::PodLifecycleData>::finished
+FNDA:1,<sk_core::k8s::PodLifecycleData>::empty
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd>::partial_cmp
+FNDA:0,sk_core::k8s::pod_lifecycle::test::test_min_some::case_2_left_some
+FNDA:0,<sk_core::k8s::PodLifecycleData>::end_ts
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<core::option::Option<&sk_core::k8s::PodLifecycleData>>>::partial_cmp::{closure#0}
+FNDA:0,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#0}
+FNDA:0,sk_core::k8s::pod_lifecycle::get_start_end_ts::{closure#1}
+FNDA:1,sk_core::k8s::pod_lifecycle::test::test_min_some
+FNF:78
+FNH:35
+BRF:0
+BRH:0
+DA:38,82
+DA:39,82
+DA:40,15
+DA:41,38
+DA:42,29
+DA:44,82
+DA:46,82
+DA:47,82
+DA:48,82
+DA:50,82
+DA:51,82
+DA:52,3
+DA:53,3
+DA:54,3
+DA:55,3
+DA:56,3
+DA:57,79
+DA:59,82
+DA:60,71
+DA:61,71
+DA:62,71
+DA:63,71
+DA:64,71
+DA:65,31
+DA:66,40
+DA:67,71
+DA:69,15
+DA:76,82
+DA:77,38
+DA:78,45
+DA:79,82
+DA:80,82
+DA:82,0
+DA:83,0
+DA:84,0
+DA:85,0
+DA:87,0
+DA:89,21
+DA:90,21
+DA:91,21
+DA:92,0
+DA:93,0
+DA:95,21
+DA:97,84
+DA:98,84
+DA:99,84
+DA:100,84
+DA:101,84
+DA:102,42
+DA:103,42
+DA:104,0
+DA:106,84
+DA:108,21
+DA:109,21
+DA:110,21
+DA:111,21
+DA:112,21
+DA:113,21
+DA:114,21
+DA:115,21
+DA:116,7
+DA:117,7
+DA:119,7
+DA:120,7
+DA:121,0
+DA:122,0
+DA:124,0
+DA:126,7
+DA:129,21
+DA:131,43
+DA:132,43
+DA:133,43
+DA:135,0
+DA:136,0
+DA:137,0
+DA:139,49
+DA:140,49
+DA:141,49
+DA:160,65
+DA:161,65
+DA:163,5
+DA:164,4
+DA:166,1
+DA:169,29
+DA:170,2
+DA:171,25
+DA:172,25
+DA:173,15
+DA:175,10
+DA:178,2
+DA:180,31
+DA:181,2
+DA:182,25
+DA:183,25
+DA:184,15
+DA:186,10
+DA:189,4
+DA:190,4
+DA:191,1
+DA:193,3
+DA:198,65
+DA:201,74
+DA:202,74
+DA:203,0
+DA:204,0
+DA:205,74
+DA:206,74
+DA:207,0
+DA:208,0
+DA:209,74
+DA:210,74
+DA:211,74
+DA:212,74
+DA:215,42
+DA:216,42
+DA:217,4
+DA:218,38
+DA:220,42
+DA:224,84
+DA:225,84
+DA:226,13
+DA:227,71
+DA:229,84
+DA:239,78
+DA:240,78
+DA:241,2
+DA:242,76
+DA:243,68
+DA:245,8
+DA:247,78
+LF:130
+LH:112
+end_of_record
+SF:sk-cli/src/validation/validator.rs
+FN:31,<skctl::validation::validator::ValidatorCode>::parse
+FN:95,skctl::validation::validator::flatten_str::<_>
+FN:68,<<skctl::validation::validator::Validator as serde::ser::Serialize>::serialize::__SerializeWith as serde::ser::Serialize>::serialize::<_>
+FN:82,<skctl::validation::validator::Validator>::check_next_event
+FN:48,<skctl::validation::validator::ValidatorCode as core::fmt::Display>::fmt
+FN:90,<skctl::validation::validator::Validator>::help
+FN:90,<skctl::validation::validator::Validator>::help
+FN:68,<<skctl::validation::validator::Validator as serde::ser::Serialize>::serialize::__SerializeWith as serde::ser::Serialize>::serialize::<_>
+FN:106,skctl::validation::validator::tests::test_parse_validator_code
+FN:86,<skctl::validation::validator::Validator>::reset
+FN:106,skctl::validation::validator::tests::test_parse_validator_code
+FN:31,<skctl::validation::validator::ValidatorCode>::parse
+FN:82,<skctl::validation::validator::Validator>::check_next_event
+FN:86,<skctl::validation::validator::Validator>::reset
+FN:106,skctl::validation::validator::tests::test_parse_validator_code::test_parse_validator_code
+FN:95,skctl::validation::validator::flatten_str::<_>
+FN:48,<skctl::validation::validator::ValidatorCode as core::fmt::Display>::fmt
+FN:106,skctl::validation::validator::tests::test_parse_validator_code::test_parse_validator_code
+FNDA:1,<skctl::validation::validator::ValidatorCode>::parse
+FNDA:0,skctl::validation::validator::flatten_str::<_>
+FNDA:0,<<skctl::validation::validator::Validator as serde::ser::Serialize>::serialize::__SerializeWith as serde::ser::Serialize>::serialize::<_>
+FNDA:1,<skctl::validation::validator::Validator>::check_next_event
+FNDA:0,<skctl::validation::validator::ValidatorCode as core::fmt::Display>::fmt
+FNDA:0,<skctl::validation::validator::Validator>::help
+FNDA:0,<skctl::validation::validator::Validator>::help
+FNDA:0,<<skctl::validation::validator::Validator as serde::ser::Serialize>::serialize::__SerializeWith as serde::ser::Serialize>::serialize::<_>
+FNDA:0,skctl::validation::validator::tests::test_parse_validator_code
+FNDA:0,<skctl::validation::validator::Validator>::reset
+FNDA:1,skctl::validation::validator::tests::test_parse_validator_code
+FNDA:0,<skctl::validation::validator::ValidatorCode>::parse
+FNDA:0,<skctl::validation::validator::Validator>::check_next_event
+FNDA:1,<skctl::validation::validator::Validator>::reset
+FNDA:0,skctl::validation::validator::tests::test_parse_validator_code::test_parse_validator_code
+FNDA:0,skctl::validation::validator::flatten_str::<_>
+FNDA:0,<skctl::validation::validator::ValidatorCode as core::fmt::Display>::fmt
+FNDA:1,skctl::validation::validator::tests::test_parse_validator_code::test_parse_validator_code
+FNF:18
+FNH:5
+BRF:0
+BRH:0
+DA:31,3
+DA:32,3
+DA:33,0
+DA:34,3
+DA:35,3
+DA:36,3
+DA:37,3
+DA:38,1
+DA:39,1
+DA:40,1
+DA:42,2
+DA:43,2
+DA:44,3
+DA:48,0
+DA:49,0
+DA:50,0
+DA:51,0
+DA:52,0
+DA:53,0
+DA:54,0
+DA:58,0
+DA:82,924
+DA:83,924
+DA:84,924
+DA:86,17
+DA:87,17
+DA:88,17
+DA:90,0
+DA:91,0
+DA:92,0
+DA:95,0
+DA:96,0
+DA:97,0
+LF:33
+LH:18
+end_of_record
+SF:sk-cli/src/xray/view/helpers.rs
+FN:48,skctl::xray::view::helpers::make_object_spans
+FN:89,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#2}
+FN:127,skctl::xray::view::helpers::format_duration
+FN:86,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#1}
+FN:79,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>
+FN:86,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#1}
+FN:85,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#0}
+FN:79,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>
+FN:26,skctl::xray::view::helpers::make_event_spans::{closure#0}
+FN:79,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>
+FN:17,skctl::xray::view::helpers::make_event_spans
+FN:127,skctl::xray::view::helpers::format_duration
+FN:89,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#2}
+FN:85,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#0}
+FN:86,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#1}
+FN:85,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#0}
+FN:79,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>
+FN:60,skctl::xray::view::helpers::make_object_spans::{closure#0}
+FN:17,skctl::xray::view::helpers::make_event_spans
+FN:85,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#0}
+FN:86,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#1}
+FN:85,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#0}
+FN:89,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#2}
+FN:86,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#1}
+FN:48,skctl::xray::view::helpers::make_object_spans
+FN:85,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#0}
+FN:89,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#2}
+FN:79,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>
+FN:86,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#1}
+FN:89,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#2}
+FN:26,skctl::xray::view::helpers::make_event_spans::{closure#0}
+FN:79,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>
+FN:60,skctl::xray::view::helpers::make_object_spans::{closure#0}
+FN:89,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#2}
+FNDA:0,skctl::xray::view::helpers::make_object_spans
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#2}
+FNDA:0,skctl::xray::view::helpers::format_duration
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#1}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#1}
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#0}
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>
+FNDA:0,skctl::xray::view::helpers::make_event_spans::{closure#0}
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>
+FNDA:1,skctl::xray::view::helpers::make_event_spans
+FNDA:1,skctl::xray::view::helpers::format_duration
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#2}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#0}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#1}
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#0}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>
+FNDA:0,skctl::xray::view::helpers::make_object_spans::{closure#0}
+FNDA:0,skctl::xray::view::helpers::make_event_spans
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#0}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#1}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#0}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#2}
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#1}
+FNDA:1,skctl::xray::view::helpers::make_object_spans
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::map::Map<core::slice::iter::Iter<skctl::validation::annotated_trace::AnnotatedTraceEvent>, skctl::xray::view::render_event_list::{closure#0}>>::{closure#0}
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#2}
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#1}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>::{closure#2}
+FNDA:1,skctl::xray::view::helpers::make_event_spans::{closure#0}
+FNDA:0,skctl::xray::view::helpers::format_list_entries::<core::iter::sources::once::Once<(ratatui::text::span::Span, ratatui::text::span::Span)>>
+FNDA:1,skctl::xray::view::helpers::make_object_spans::{closure#0}
+FNDA:1,skctl::xray::view::helpers::format_list_entries::<core::iter::adapters::peekable::Peekable<core::iter::adapters::map::Map<core::iter::adapters::enumerate::Enumerate<core::iter::adapters::chain::Chain<core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>, core::iter::adapters::zip::Zip<core::slice::iter::Iter<kube_core::dynamic::DynamicObject>, core::iter::sources::repeat::Repeat<char>>>>, skctl::xray::view::render_event_list::{closure#1}::{closure#0}>>>::{closure#2}
+FNF:34
+FNH:17
+BRF:0
+BRH:0
+DA:17,1820
+DA:18,1820
+DA:19,1820
+DA:20,1820
+DA:21,1820
+DA:22,1820
+DA:23,1820
+DA:24,1820
+DA:25,1820
+DA:26,1820
+DA:27,180
+DA:28,90
+DA:29,0
+DA:30,90
+DA:33,90
+DA:34,1820
+DA:35,1820
+DA:36,1820
+DA:37,1730
+DA:39,90
+DA:40,90
+DA:41,90
+DA:42,90
+DA:43,90
+DA:44,90
+DA:46,1820
+DA:48,171
+DA:49,171
+DA:50,171
+DA:51,171
+DA:52,171
+DA:53,171
+DA:54,171
+DA:55,171
+DA:56,171
+DA:57,171
+DA:58,171
+DA:59,171
+DA:60,171
+DA:61,10
+DA:62,0
+DA:63,10
+DA:65,10
+DA:66,171
+DA:67,171
+DA:68,161
+DA:70,10
+DA:71,10
+DA:72,10
+DA:73,10
+DA:74,10
+DA:75,10
+DA:77,171
+DA:79,23
+DA:80,23
+DA:81,23
+DA:82,23
+DA:83,23
+DA:84,23
+DA:85,1000
+DA:86,23
+DA:87,23
+DA:88,23
+DA:89,1000
+DA:90,1000
+DA:91,1000
+DA:92,1000
+DA:93,1000
+DA:94,1000
+DA:95,1000
+DA:96,1000
+DA:97,1000
+DA:98,1000
+DA:99,1000
+DA:100,1000
+DA:101,1000
+DA:102,1000
+DA:103,1000
+DA:104,1000
+DA:108,1000
+DA:109,950
+DA:110,50
+DA:112,1000
+DA:113,1000
+DA:114,1000
+DA:115,1000
+DA:116,1000
+DA:117,2
+DA:118,2
+DA:119,2
+DA:120,998
+DA:122,1000
+DA:123,1000
+DA:124,23
+DA:125,23
+DA:127,1820
+DA:128,1820
+DA:129,1820
+DA:130,1820
+DA:133,1820
+DA:134,1820
+LF:101
+LH:99
+end_of_record
+SF:sk-core/src/k8s/owners.rs
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:70,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:22,<sk_core::k8s::owners::OwnersCache>::new
+FN:70,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:70,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:70,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FN:26,<sk_core::k8s::owners::OwnersCache>::new_from_parts
+FN:70,sk_core::k8s::owners::build_owner_selector::<_>
+FN:70,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FN:70,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<_>::{closure#0}
+FN:22,<sk_core::k8s::owners::OwnersCache>::new
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<_>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:70,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:26,<sk_core::k8s::owners::OwnersCache>::new_from_parts
+FN:70,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FN:65,<sk_core::k8s::owners::OwnersCache>::lookup
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FN:22,<sk_core::k8s::owners::OwnersCache>::new
+FN:70,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FN:26,<sk_core::k8s::owners::OwnersCache>::new_from_parts
+FN:65,<sk_core::k8s::owners::OwnersCache>::lookup
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FN:70,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FN:65,<sk_core::k8s::owners::OwnersCache>::lookup
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FN:35,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::new
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:1,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::new_from_parts
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<_>
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<_>::{closure#0}
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::new
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<_>
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::new_from_parts
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::lookup
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>::{closure#0}
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::new
+FNDA:1,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::new_from_parts
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::lookup
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<k8s_openapi::v1_27::api::core::v1::pod::Pod>::{closure#0}
+FNDA:0,sk_core::k8s::owners::build_owner_selector::<kube_core::dynamic::DynamicObject>
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FNDA:1,<sk_core::k8s::owners::OwnersCache>::lookup
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FNDA:0,<sk_core::k8s::owners::OwnersCache>::compute_owner_chain::<kube_core::dynamic::DynamicObject>
+FNF:42
+FNH:15
+BRF:0
+BRH:0
+DA:22,120
+DA:23,120
+DA:24,120
+DA:26,36
+DA:27,36
+DA:28,36
+DA:35,21
+DA:36,21
+DA:37,21
+DA:38,21
+DA:39,21
+DA:40,21
+DA:41,21
+DA:42,21
+DA:43,8
+DA:44,8
+DA:45,21
+DA:46,21
+DA:47,21
+DA:48,23
+DA:49,21
+DA:50,21
+DA:51,21
+DA:52,21
+DA:53,21
+DA:54,2
+DA:55,2
+DA:56,4
+DA:57,21
+DA:58,21
+DA:59,21
+DA:60,8
+DA:61,8
+DA:62,21
+DA:63,21
+DA:65,56
+DA:66,56
+DA:67,56
+DA:70,2
+DA:71,2
+DA:72,0
+DA:76,2
+DA:79,2
+DA:80,2
+LF:44
+LH:43
+end_of_record
+SF:sk-core/src/logging.rs
+FN:3,sk_core::logging::setup
+FN:3,sk_core::logging::setup
+FN:3,sk_core::logging::setup
+FNDA:0,sk_core::logging::setup
+FNDA:0,sk_core::logging::setup
+FNDA:0,sk_core::logging::setup
+FNF:3
+FNH:0
+BRF:0
+BRH:0
+DA:3,0
+DA:4,0
+DA:5,0
+DA:6,0
+DA:7,0
+DA:8,0
+DA:9,0
+DA:10,0
+DA:11,0
+DA:12,0
+LF:10
+LH:0
+end_of_record
+SF:sk-store/src/lib.rs
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf_st::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::times::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf_st::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::delete_obj
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::create_or_update_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::constant::BooleanPredicate>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::test_handle_event_restarted::{closure#0}::test_handle_event_restarted::{closure#0}::{closure#3}>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::start_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::is_done
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::new
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore>::expect_has_obj
+FN:125,<sk_store::ExportedTrace>::prepend_event
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::ord::EqPredicate<core::option::Option<k8s_openapi::v1_27::api::core::v1::pod::Pod>>, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::end_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::times::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::in_sequence
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::matches
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::default::Default>::default
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::constant::BooleanPredicate>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::new
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::expect
+FN:50,<sk_store::TraceEvent>::is_empty
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc>::call_mut
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning::<sk_driver::tests::mutation_test::test_mutate_pod::{closure#0}::test_mutate_pod::{closure#0}::{closure#0}>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::new
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning_st::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::new
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::with::<_, _>
+FN:99,<sk_store::mock::MockTraceStore>::expect_start_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::MockTraceStore as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::return_const
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::is_done
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::create_or_update_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf_st::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::verify_sequence
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::start_ts
+FN:99,<sk_store::mock::MockTraceStore>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::ord::EqPredicate<core::option::Option<k8s_openapi::v1_27::api::core::v1::pod::Pod>>, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc>::call_mut
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf_st::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#0}
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::matches
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:99,<sk_store::mock::MockTraceStore>::expect_create_or_update_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::checkpoint
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::with::<_, _, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::constant::BooleanPredicate>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::end_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore>::expect_update_all_objs_for_gvk
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::new
+FN:99,<sk_store::mock::MockTraceStore>::expect_record_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore>::expect_iter
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::ord::EqPredicate<core::option::Option<k8s_openapi::v1_27::api::core::v1::pod::Pod>>, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::with::<_, _, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::MockTraceStore_TraceStorable>::checkpoint
+FN:99,<sk_store::mock::MockTraceStore>::expect_has_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf_st::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::never
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::config
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::has_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::iter
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::MockTraceStore as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc as core::default::Default>::default
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::MockTraceStore>::expect_lookup_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::satisfy_sequence
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::end_ts
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::start_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::with::<predicates::constant::BooleanPredicate, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<u64>, predicates::ord::EqPredicate<usize>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once_st::<_>
+FN:46,<sk_store::TraceEvent>::len
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::fmt::Display>::fmt
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::verify_sequence
+FN:125,<sk_store::ExportedTrace>::prepend_event
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::times::<_>
+FN:99,<sk_store::mock::MockTraceStore>::expect_end_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::MockTraceStore>::expect_record_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc>::call
+FN:50,<sk_store::TraceEvent>::is_empty
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::expect
+FN:99,<sk_store::mock::MockTraceStore>::expect_delete_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>::{closure#0}
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::MockTraceStore>::expect_config
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::is_done
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::make_pod_handler_store::{closure#0}>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::default::Default>::default
+FN:99,<sk_store::mock::MockTraceStore>::expect_config
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning::<sk_driver::tests::mutation_test::test_mutate_pod::{closure#0}::test_mutate_pod::{closure#0}::{closure#1}>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::with::<_, _, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore>::expect_record_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once_st::<_>
+FN:131,<sk_store::ExportedTrace>::events
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::MockTraceStore>::expect_start_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::fmt::Display>::fmt
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::call
+FN:99,<sk_store::mock::MockTraceStore>::expect_create_or_update_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::call
+FN:50,<sk_store::TraceEvent>::is_empty
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::satisfy_sequence
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::config
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::call
+FN:99,<sk_store::mock::MockTraceStore>::expect_config
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::MockTraceStore>::expect_start_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::new
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::times::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::with::<_, _, _>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::in_sequence
+FN:99,<sk_store::mock::MockTraceStore>::expect_update_all_objs_for_gvk
+FN:99,<sk_store::mock::MockTraceStore>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::satisfy_sequence
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations as core::default::Default>::default
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::with::<predicates::constant::BooleanPredicate, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<u64>, predicates::ord::EqPredicate<usize>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::is_done
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::MockTraceStore>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation as core::default::Default>::default
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::expect
+FN:125,<sk_store::ExportedTrace>::prepend_event
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::never
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches::{closure#0}
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::iter
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::MockTraceStore_TraceStorable>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::is_done
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<_, _, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning_st::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf::<_>
+FN:99,<sk_store::mock::MockTraceStore>::expect_create_or_update_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::matches
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::in_sequence
+FN:99,<sk_store::mock::MockTraceStore>::expect_iter
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::checkpoint
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:46,<sk_store::TraceEvent>::len
+FN:99,<sk_store::mock::MockTraceStore>::expect_end_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::test_handle_event_restarted::{closure#0}::test_handle_event_restarted::{closure#0}::{closure#2}>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf_st::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::fmt::Display>::fmt
+FN:46,<sk_store::TraceEvent>::len
+FN:99,<sk_store::mock::MockTraceStore as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::once
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::config
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::return_const
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::is_done
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::has_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once_st::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::ord::EqPredicate<core::option::Option<k8s_openapi::v1_27::api::core::v1::pod::Pod>>, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::MockTraceStore>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::times::<usize>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::delete_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc>::call_mut
+FN:99,<sk_store::mock::MockTraceStore>::expect_has_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::new
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::matches
+FN:99,<sk_store::mock::MockTraceStore>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::call
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::times::<usize>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::verify_sequence
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::expect
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::never
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning_st::<_>
+FN:131,<sk_store::ExportedTrace>::events
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches
+FN:99,<sk_store::mock::MockTraceStore>::expect_lookup_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::with::<_, _, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::default::Default>::default
+FN:99,<sk_store::mock::MockTraceStore_TraceStorable as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc>::call_mut
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::verify_sequence
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::constant::BooleanPredicate>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::matches
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::delete_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::make_pod_handler_store::{closure#0}>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::call
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::test_handle_event_restarted::{closure#0}::test_handle_event_restarted::{closure#0}::{closure#3}>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once_st::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::with::<_, _, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning_st::<_>
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::matches
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation as core::default::Default>::default
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::expect
+FN:99,<sk_store::mock::MockTraceStore>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches
+FN:99,<sk_store::mock::MockTraceStore_TraceStorable as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc>::call_mut
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::test_handle_event_restarted::{closure#0}::test_handle_event_restarted::{closure#0}::{closure#2}>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::is_done
+FN:99,<sk_store::mock::MockTraceStore>::expect_iter
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#1}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::never
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::verify_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore_TraceStorable>::checkpoint
+FN:99,<sk_store::mock::MockTraceStore>::expect_update_all_objs_for_gvk
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::checkpoint
+FN:99,<sk_store::mock::MockTraceStore>::expect_end_ts
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::satisfy_sequence
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::create_or_update_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::default::Default>::default
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::call
+FN:99,<sk_store::mock::MockTraceStore_TraceStorable as core::default::Default>::default
+FN:131,<sk_store::ExportedTrace>::events
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<_, _, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::call
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::iter
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::MockTraceStore>::expect_lookup_pod_lifecycle
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::fmt::Display>::fmt
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::is_done
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::in_sequence
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::has_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::ops::drop::Drop>::drop
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::expect
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::new
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::with
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::times::<usize>
+FN:99,<sk_store::mock::MockTraceStore>::expect_delete_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches
+FN:62,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::MockTraceStore>::expect_delete_obj
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::times::<_>
+FN:99,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::with::<_, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf::<_>
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::with::<_, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::return_const
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::expect
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::checkpoint
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::once
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::times::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::in_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::satisfy_sequence
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::times::<usize>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::never
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches::{closure#0}
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::with::<_, _, _, _>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once_st::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::default::Default>::default
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::matches
+FN:38,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once::<_>
+FN:99,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::never
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf_st::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::times::<_>
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf_st::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::delete_obj
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::create_or_update_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::constant::BooleanPredicate>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::test_handle_event_restarted::{closure#0}::test_handle_event_restarted::{closure#0}::{closure#3}>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::start_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::is_done
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::new
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_has_obj
+FNDA:0,<sk_store::ExportedTrace>::prepend_event
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::ord::EqPredicate<core::option::Option<k8s_openapi::v1_27::api::core::v1::pod::Pod>>, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf::<_>
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::end_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::times::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::in_sequence
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::matches
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::default::Default>::default
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::constant::BooleanPredicate>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::times::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::new
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::expect
+FNDA:0,<sk_store::TraceEvent>::is_empty
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc>::call_mut
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::verify_sequence
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning::<sk_driver::tests::mutation_test::test_mutate_pod::{closure#0}::test_mutate_pod::{closure#0}::{closure#0}>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::new
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning_st::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::new
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::with::<_, _>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_start_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::new
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>
+FNDA:1,<sk_store::mock::MockTraceStore as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::return_const
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::is_done
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::create_or_update_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf_st::<_>
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::verify_sequence
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::start_ts
+FNDA:0,<sk_store::mock::MockTraceStore>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::ord::EqPredicate<core::option::Option<k8s_openapi::v1_27::api::core::v1::pod::Pod>>, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc>::call_mut
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf_st::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#0}
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::is_done
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::satisfy_sequence
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::matches
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_create_or_update_obj
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::checkpoint
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::with::<_, _, _, _>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::constant::BooleanPredicate>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::end_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_update_all_objs_for_gvk
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::new
+FNDA:1,<sk_store::mock::MockTraceStore>::expect_record_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_iter
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::once
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::ord::EqPredicate<core::option::Option<k8s_openapi::v1_27::api::core::v1::pod::Pod>>, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::with::<_, _, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::MockTraceStore_TraceStorable>::checkpoint
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_has_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf_st::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::never
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::config
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning_st::<_>
+FNDA:1,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::has_obj
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::iter
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#1}
+FNDA:1,<sk_store::mock::MockTraceStore as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc as core::default::Default>::default
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_lookup_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::end_ts
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::start_ts
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::with::<predicates::constant::BooleanPredicate, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<u64>, predicates::ord::EqPredicate<usize>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::TraceEvent>::len
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::fmt::Display>::fmt
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::verify_sequence
+FNDA:0,<sk_store::ExportedTrace>::prepend_event
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::times::<_>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_end_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches::{closure#0}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_record_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning::<_>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc>::call
+FNDA:0,<sk_store::TraceEvent>::is_empty
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::expect
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_delete_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#1}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_config
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::is_done
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::times::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::make_pod_handler_store::{closure#0}>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::times::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::once
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_config
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::times::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning::<sk_driver::tests::mutation_test::test_mutate_pod::{closure#0}::test_mutate_pod::{closure#0}::{closure#1}>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::with::<_, _, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc>::call_mut
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_record_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::ExportedTrace>::events
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::times::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_start_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::fmt::Display>::fmt
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::call
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_create_or_update_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::matches
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::call
+FNDA:0,<sk_store::TraceEvent>::is_empty
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::config
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::call
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::call
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_config
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_start_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::new
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::times::<_>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::with::<_, _, _>
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#1}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::in_sequence
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_update_all_objs_for_gvk
+FNDA:0,<sk_store::mock::MockTraceStore>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::satisfy_sequence
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:1,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::times::<usize>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#0}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations as core::default::Default>::default
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::with::<predicates::constant::BooleanPredicate, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<u64>, predicates::ord::EqPredicate<usize>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::in_sequence
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::call
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::is_done
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:1,<sk_store::mock::MockTraceStore>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation as core::default::Default>::default
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::once
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf::<_>
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::lookup_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::expect
+FNDA:1,<sk_store::ExportedTrace>::prepend_event
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::never
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::never
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::new
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches::{closure#0}
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::iter
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::call
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::MockTraceStore_TraceStorable>::checkpoint
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::is_done
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::fmt::Display>::fmt
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common as core::ops::drop::Drop>::drop
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<_, _, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::matches
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning_st::<_>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches::{closure#0}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#1}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_create_or_update_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::matches
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_iter
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::checkpoint
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::TraceEvent>::len
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_end_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::test_handle_event_restarted::{closure#0}::test_handle_event_restarted::{closure#0}::{closure#2}>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf_st::<_>
+FNDA:1,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>::{closure#0}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::TraceEvent>::len
+FNDA:0,<sk_store::mock::MockTraceStore as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::once
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::config
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::return_const
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::is_done
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::has_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once_st::<_>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::ord::EqPredicate<core::option::Option<k8s_openapi::v1_27::api::core::v1::pod::Pod>>, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::MockTraceStore>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf::<_>
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::delete_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc>::call_mut
+FNDA:1,<sk_store::mock::MockTraceStore>::expect_has_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::new
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::call
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::matches
+FNDA:0,<sk_store::mock::MockTraceStore>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::once
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc>::call_mut
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::new
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::call
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::times::<usize>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::verify_sequence
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::expect
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::never
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::ExportedTrace>::events
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches
+FNDA:1,<sk_store::mock::MockTraceStore>::expect_lookup_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::with::<_, _, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::times::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::default::Default>::default
+FNDA:1,<sk_store::mock::MockTraceStore_TraceStorable as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Rfunc>::call_mut
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<&mut rmp_serde::decode::MapAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::verify_sequence
+FNDA:1,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Rfunc>::call_mut
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::constant::BooleanPredicate>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::matches
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::delete_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::make_pod_handler_store::{closure#0}>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::call
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::withf_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::expect
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>::{closure#0}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::test_handle_event_restarted::{closure#0}::test_handle_event_restarted::{closure#0}::{closure#3}>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once_st::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::call
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const::<_>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::with::<_, _, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning_st::<_>
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::matches
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::record_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::call::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation as core::default::Default>::default
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::expect
+FNDA:1,<sk_store::mock::MockTraceStore>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches
+FNDA:0,<sk_store::mock::MockTraceStore_TraceStorable as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_once_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Rfunc>::call_mut
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning::<sk_store::watchers::tests::pod_watcher_test::test_handle_event_restarted::{closure#0}::test_handle_event_restarted::{closure#0}::{closure#2}>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::is_done
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_iter
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::with::<predicates::ord::EqPredicate<alloc::string::String>, predicates::constant::BooleanPredicate, predicates::ord::EqPredicate<alloc::vec::Vec<k8s_openapi::v1_27::apimachinery::pkg::apis::meta::v1::owner_reference::OwnerReference>>, predicates::ord::EqPredicate<sk_core::k8s::PodLifecycleData>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::call::{closure#1}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::times::<usize>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::is_done
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::never
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::verify_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_const_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc as core::default::Default>::default
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore_TraceStorable>::checkpoint
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_update_all_objs_for_gvk
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher>::matches::{closure#0}
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_end_ts
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::satisfy_sequence
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::create_or_update_obj
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Rfunc>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::returning::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common as core::default::Default>::default
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::times::<usize>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::call
+FNDA:1,<sk_store::mock::MockTraceStore_TraceStorable as core::default::Default>::default
+FNDA:1,<sk_store::ExportedTrace>::events
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::with::<_, _, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::call
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::iter
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectations>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::return_once_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_lookup_pod_lifecycle
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::new
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::is_done
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::returning::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::in_sequence
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::has_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Rfunc as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::withf_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations>::expect
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectations>::checkpoint
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::new
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::with
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::return_const_st::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_delete_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches
+FNDA:0,<<sk_store::ExportedTrace as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::MockTraceStore>::expect_delete_obj
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectation>::times::<_>
+FNDA:0,<sk_store::mock::MockTraceStore as sk_store::TraceStorable>::update_all_objs_for_gvk
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Expectation>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::with::<_, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::withf::<_>
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::returning_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectations as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::with::<_, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Expectation>::return_const
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::expect
+FNDA:0,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Expectation>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Common>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectations>::checkpoint
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Expectation>::once
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Common>::times::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common>::withf::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::in_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Common>::satisfy_sequence
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Expectation>::times::<usize>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__has_obj::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::call
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__end_ts::Common>::never
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Matcher>::matches::{closure#0}
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Common>::with::<_, _, _, _>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__update_all_objs_for_gvk::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Common as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__delete_obj::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectation>::return_once_st::<_>
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__record_pod_lifecycle::Matcher>::matches
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__config::Matcher as core::default::Default>::default
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__create_or_update_obj::Expectations>::call
+FNDA:1,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__lookup_pod_lifecycle::Expectation>::matches
+FNDA:1,<<sk_store::TraceEvent as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__iter::Expectation>::return_once::<_>
+FNDA:0,<sk_store::mock::__mock_MockTraceStore_TraceStorable::__start_ts::Expectations>::call
+FNF:1540
+FNH:141
+BRF:0
+BRH:0
+DA:46,0
+DA:47,0
+DA:48,0
+DA:50,0
+DA:51,0
+DA:52,0
+LF:6
+LH:0
+end_of_record
+SF:sk-ctrl/src/context.rs
+FN:23,<sk_ctrl::context::SimulationContext>::new
+FN:38,<sk_ctrl::context::SimulationContext>::with_sim
+FNDA:1,<sk_ctrl::context::SimulationContext>::new
+FNDA:1,<sk_ctrl::context::SimulationContext>::with_sim
+FNF:2
+FNH:2
+BRF:0
+BRH:0
+DA:23,13
+DA:24,13
+DA:25,13
+DA:26,13
+DA:27,13
+DA:28,13
+DA:29,13
+DA:30,13
+DA:31,13
+DA:32,13
+DA:33,13
+DA:34,13
+DA:35,13
+DA:36,13
+DA:38,13
+DA:39,13
+DA:40,13
+DA:41,13
+DA:42,13
+DA:43,13
+DA:44,13
+DA:45,13
+DA:46,13
+DA:47,13
+DA:48,13
+DA:49,13
+LF:26
+LH:26
+end_of_record
+SF:sk-core/src/errors.rs
+FN:74,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#0}::{closure#0}
+FN:27,<sk_core::k8s::KubernetesError>::field_not_found
+FN:74,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#0}::{closure#0}
+FN:35,<sk_core::k8s::KubernetesError>::malformed_container_state
+FN:74,sk_ctrl::controller::error_policy::{closure#1}
+FN:35,<sk_core::k8s::KubernetesError>::malformed_label_selector
+FN:74,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#1}
+FN:74,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#0}
+FN:74,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#2}
+FN:74,<sk_store::watchers::ObjWatcher<_>>::start::{closure#0}::{closure#0}::{closure#0}
+FN:74,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#0}
+FN:27,<sk_ctrl::errors::SkControllerError>::namespace_not_found
+FN:27,<sk_ctrl::errors::SkControllerError>::missing_status_field
+FN:74,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#2}
+FN:27,<sk_core::k8s::KubernetesError>::field_not_found
+FN:27,<sk_core::k8s::KubernetesError>::lease_held_by_other
+FN:74,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#0}
+FN:74,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#1}
+FN:35,<sk_core::k8s::KubernetesError>::malformed_container_state
+FN:74,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#2}
+FN:35,<sk_core::k8s::KubernetesError>::malformed_label_selector
+FN:35,<sk_core::k8s::KubernetesError>::malformed_container_state
+FN:27,<sk_core::k8s::KubernetesError>::lease_held_by_other
+FN:27,<sk_driver::runner::SkDriverError>::cleanup_timeout
+FN:35,<sk_core::k8s::KubernetesError>::malformed_label_selector
+FN:27,<sk_core::k8s::KubernetesError>::field_not_found
+FN:27,<sk_core::k8s::KubernetesError>::lease_held_by_other
+FN:27,<sk_driver::runner::SkDriverError>::cleanup_failed
+FN:27,<sk_ctrl::errors::SkControllerError>::configmap_not_found
+FN:74,<sk_store::watchers::ObjWatcher<_>>::start::{closure#0}::{closure#1}
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#0}::{closure#0}
+FNDA:1,<sk_core::k8s::KubernetesError>::field_not_found
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#0}::{closure#0}
+FNDA:0,<sk_core::k8s::KubernetesError>::malformed_container_state
+FNDA:0,sk_ctrl::controller::error_policy::{closure#1}
+FNDA:0,<sk_core::k8s::KubernetesError>::malformed_label_selector
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#1}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#2}
+FNDA:0,<sk_store::watchers::ObjWatcher<_>>::start::{closure#0}::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#0}
+FNDA:1,<sk_ctrl::errors::SkControllerError>::namespace_not_found
+FNDA:0,<sk_ctrl::errors::SkControllerError>::missing_status_field
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#2}
+FNDA:1,<sk_core::k8s::KubernetesError>::field_not_found
+FNDA:0,<sk_core::k8s::KubernetesError>::lease_held_by_other
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#1}
+FNDA:0,<sk_core::k8s::KubernetesError>::malformed_container_state
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}::{closure#2}
+FNDA:0,<sk_core::k8s::KubernetesError>::malformed_label_selector
+FNDA:1,<sk_core::k8s::KubernetesError>::malformed_container_state
+FNDA:0,<sk_core::k8s::KubernetesError>::lease_held_by_other
+FNDA:1,<sk_driver::runner::SkDriverError>::cleanup_timeout
+FNDA:1,<sk_core::k8s::KubernetesError>::malformed_label_selector
+FNDA:0,<sk_core::k8s::KubernetesError>::field_not_found
+FNDA:1,<sk_core::k8s::KubernetesError>::lease_held_by_other
+FNDA:1,<sk_driver::runner::SkDriverError>::cleanup_failed
+FNDA:0,<sk_ctrl::errors::SkControllerError>::configmap_not_found
+FNDA:0,<sk_store::watchers::ObjWatcher<_>>::start::{closure#0}::{closure#1}
+FNF:30
+FNH:8
+BRF:0
+BRH:0
+DA:27,14
+DA:28,14
+DA:29,14
+DA:35,6
+DA:36,6
+DA:37,6
+DA:74,0
+DA:75,0
+DA:76,0
+DA:77,0
+DA:78,0
+DA:79,0
+DA:80,0
+DA:81,0
+DA:82,0
+DA:83,0
+DA:84,0
+DA:85,0
+DA:86,0
+DA:87,0
+DA:88,0
+LF:21
+LH:6
+end_of_record
+SF:sk-cli/src/xray/mod.rs
+FN:19,<skctl::xray::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:30,skctl::xray::run_loop::<_>
+FN:19,<skctl::xray::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:30,skctl::xray::run_loop::<_>
+FN:22,skctl::xray::cmd
+FN:19,<skctl::xray::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:22,skctl::xray::cmd::{closure#0}
+FN:22,skctl::xray::cmd
+FN:36,skctl::xray::run_loop::<_>::{closure#0}
+FN:19,<skctl::xray::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:36,skctl::xray::run_loop::<_>::{closure#0}
+FN:22,skctl::xray::cmd::{closure#0}
+FNDA:0,<skctl::xray::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::xray::run_loop::<_>
+FNDA:0,<skctl::xray::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::xray::run_loop::<_>
+FNDA:0,skctl::xray::cmd
+FNDA:0,<skctl::xray::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::xray::cmd::{closure#0}
+FNDA:0,skctl::xray::cmd
+FNDA:0,skctl::xray::run_loop::<_>::{closure#0}
+FNDA:0,<skctl::xray::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::xray::run_loop::<_>::{closure#0}
+FNDA:0,skctl::xray::cmd::{closure#0}
+FNF:12
+FNH:0
+BRF:0
+BRH:0
+DA:19,0
+DA:22,0
+DA:23,0
+DA:24,0
+DA:25,0
+DA:26,0
+DA:27,0
+DA:28,0
+DA:30,0
+DA:31,0
+DA:32,0
+DA:33,0
+DA:34,0
+DA:35,0
+DA:36,0
+DA:37,0
+DA:38,0
+DA:40,0
+DA:41,0
+LF:19
+LH:0
+end_of_record
+SF:sk-driver/src/mutation.rs
+FN:96,sk_driver::mutation::add_lifecycle_annotation
+FN:131,sk_driver::mutation::add_node_selector_tolerations
+FN:37,<sk_driver::mutation::MutationData>::count::{closure#0}
+FN:145,sk_driver::mutation::into_pod_review
+FN:70,sk_driver::mutation::mutate_pod::{closure#0}
+FN:70,sk_driver::mutation::mutate_pod::{closure#0}::{closure#0}
+FN:83,sk_driver::mutation::mutate_pod::{closure#0}::{closure#0}::{closure#0}
+FN:42,sk_driver::mutation::handler::{closure#0}::{closure#0}
+FN:42,sk_driver::mutation::handler::{closure#0}
+FN:41,<sk_driver::mutation::handler>::into_route
+FN:41,<sk_driver::mutation::handler>::into_info::monomorphized_function
+FN:154,sk_driver::mutation::to_annotation_patch
+FN:41,<sk_driver::mutation::handler>::into_info::monomorphized_function::{closure#0}
+FN:35,<sk_driver::mutation::MutationData>::count
+FN:41,<sk_driver::mutation::handler>::into_info
+FN:59,sk_driver::mutation::handler::{closure#0}::{closure#0}::{closure#0}
+FN:31,<sk_driver::mutation::MutationData>::new
+FNDA:1,sk_driver::mutation::add_lifecycle_annotation
+FNDA:1,sk_driver::mutation::add_node_selector_tolerations
+FNDA:0,<sk_driver::mutation::MutationData>::count::{closure#0}
+FNDA:1,sk_driver::mutation::into_pod_review
+FNDA:1,sk_driver::mutation::mutate_pod::{closure#0}
+FNDA:1,sk_driver::mutation::mutate_pod::{closure#0}::{closure#0}
+FNDA:1,sk_driver::mutation::mutate_pod::{closure#0}::{closure#0}::{closure#0}
+FNDA:1,sk_driver::mutation::handler::{closure#0}::{closure#0}
+FNDA:1,sk_driver::mutation::handler::{closure#0}
+FNDA:0,<sk_driver::mutation::handler>::into_route
+FNDA:0,<sk_driver::mutation::handler>::into_info::monomorphized_function
+FNDA:1,sk_driver::mutation::to_annotation_patch
+FNDA:0,<sk_driver::mutation::handler>::into_info::monomorphized_function::{closure#0}
+FNDA:1,<sk_driver::mutation::MutationData>::count
+FNDA:0,<sk_driver::mutation::handler>::into_info
+FNDA:1,sk_driver::mutation::handler::{closure#0}::{closure#0}::{closure#0}
+FNDA:1,<sk_driver::mutation::MutationData>::new
+FNF:17
+FNH:12
+BRF:0
+BRH:0
+DA:31,4
+DA:32,4
+DA:33,4
+DA:35,1
+DA:36,1
+DA:37,1
+DA:38,1
+DA:41,0
+DA:42,4
+DA:59,1
+DA:60,1
+DA:61,1
+DA:62,1
+DA:70,6
+DA:83,3
+DA:96,2
+DA:97,2
+DA:98,2
+DA:99,2
+DA:100,2
+DA:101,2
+DA:102,2
+DA:103,2
+DA:104,2
+DA:105,2
+DA:106,2
+DA:107,2
+DA:108,1
+DA:109,1
+DA:111,1
+DA:112,1
+DA:113,1
+DA:114,1
+DA:115,1
+DA:116,1
+DA:117,1
+DA:118,0
+DA:119,1
+DA:120,1
+DA:121,1
+DA:123,0
+DA:126,1
+DA:128,2
+DA:129,2
+DA:131,2
+DA:132,2
+DA:133,1
+DA:134,1
+DA:135,1
+DA:136,1
+DA:137,1
+DA:138,1
+DA:139,1
+DA:140,1
+DA:141,1
+DA:142,2
+DA:145,2
+DA:146,2
+DA:147,2
+DA:148,2
+DA:149,2
+DA:150,2
+DA:151,2
+DA:152,2
+DA:154,1
+DA:155,1
+DA:156,0
+DA:157,1
+DA:158,1
+DA:159,1
+DA:160,1
+DA:162,1
+LF:72
+LH:68
+end_of_record
+SF:sk-core/src/k8s/apiset.rs
+FN:45,<sk_core::k8s::apiset::ApiSet>::api_for_obj::{closure#0}
+FN:34,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FN:45,<sk_core::k8s::apiset::ApiSet>::api_for_obj::{closure#0}
+FN:34,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FN:45,<sk_core::k8s::apiset::ApiSet>::api_for_obj
+FN:22,<sk_core::k8s::apiset::ApiSet>::new
+FN:45,<sk_core::k8s::apiset::ApiSet>::api_for_obj
+FN:45,<sk_core::k8s::apiset::ApiSet>::api_for_obj
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FN:34,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FN:45,<sk_core::k8s::apiset::ApiSet>::api_for_obj::{closure#0}
+FN:22,<sk_core::k8s::apiset::ApiSet>::new
+FN:34,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FN:31,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk
+FN:22,<sk_core::k8s::apiset::ApiSet>::new
+FN:31,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for
+FN:34,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FN:34,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FN:31,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FN:45,<sk_core::k8s::apiset::ApiSet>::api_for_obj::{closure#0}
+FN:60,<sk_core::k8s::apiset::ApiSet>::api_meta_for
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_for_obj::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_for_obj::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::api_for_obj
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::new
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_for_obj
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_for_obj
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::api_for_obj::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::new
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_meta_for
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::new
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::api_meta_for
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::unnamespaced_api_by_gvk
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_meta_for::{closure#0}
+FNDA:0,<sk_core::k8s::apiset::ApiSet>::api_for_obj::{closure#0}
+FNDA:1,<sk_core::k8s::apiset::ApiSet>::api_meta_for
+FNF:28
+FNH:10
+BRF:0
+BRH:0
+DA:22,170
+DA:23,170
+DA:24,170
+DA:25,170
+DA:26,170
+DA:27,170
+DA:28,170
+DA:29,170
+DA:31,2
+DA:32,2
+DA:33,2
+DA:34,2
+DA:35,6
+DA:36,2
+DA:37,0
+DA:38,2
+DA:39,2
+DA:40,2
+DA:43,2
+DA:45,28
+DA:46,4
+DA:47,4
+DA:48,4
+DA:49,4
+DA:50,2
+DA:51,2
+DA:52,2
+DA:53,2
+DA:56,0
+DA:58,4
+DA:60,30
+DA:61,18
+DA:62,8
+DA:63,10
+DA:64,22
+DA:65,10
+DA:68,18
+LF:37
+LH:35
+end_of_record
+SF:sk-core/src/hooks.rs
+FN:75,sk_core::hooks::test::test_execute_hooks::{closure#0}::test_execute_hooks::{closure#0}
+FN:24,sk_core::hooks::execute::{closure#0}
+FN:75,sk_core::hooks::test::test_execute_hooks
+FN:75,sk_core::hooks::test::test_execute_hooks
+FN:24,sk_core::hooks::execute
+FN:76,sk_core::hooks::test::test_execute_hooks::{closure#0}::logs_assert::<_>
+FN:76,sk_core::hooks::test::test_execute_hooks::{closure#0}::{closure#0}
+FN:75,sk_core::hooks::test::test_execute_hooks::{closure#0}::test_execute_hooks::{closure#0}
+FN:24,sk_core::hooks::execute::{closure#0}
+FN:24,sk_core::hooks::execute
+FN:24,sk_core::hooks::execute
+FN:76,sk_core::hooks::test::test_execute_hooks::{closure#0}::{closure#0}
+FN:24,sk_core::hooks::execute::{closure#0}
+FN:76,sk_core::hooks::test::test_execute_hooks::{closure#0}::logs_assert::<_>
+FN:24,sk_core::hooks::execute::{closure#0}
+FN:76,sk_core::hooks::test::test_execute_hooks::{closure#0}::logs_contain
+FN:76,sk_core::hooks::test::test_execute_hooks::{closure#0}::logs_contain
+FNDA:0,sk_core::hooks::test::test_execute_hooks::{closure#0}::test_execute_hooks::{closure#0}
+FNDA:0,sk_core::hooks::execute::{closure#0}
+FNDA:1,sk_core::hooks::test::test_execute_hooks
+FNDA:0,sk_core::hooks::test::test_execute_hooks
+FNDA:0,sk_core::hooks::execute
+FNDA:0,sk_core::hooks::test::test_execute_hooks::{closure#0}::logs_assert::<_>
+FNDA:0,sk_core::hooks::test::test_execute_hooks::{closure#0}::{closure#0}
+FNDA:1,sk_core::hooks::test::test_execute_hooks::{closure#0}::test_execute_hooks::{closure#0}
+FNDA:1,sk_core::hooks::execute::{closure#0}
+FNDA:1,sk_core::hooks::execute
+FNDA:1,sk_core::hooks::execute
+FNDA:1,sk_core::hooks::test::test_execute_hooks::{closure#0}::{closure#0}
+FNDA:0,sk_core::hooks::execute::{closure#0}
+FNDA:0,sk_core::hooks::test::test_execute_hooks::{closure#0}::logs_assert::<_>
+FNDA:1,sk_core::hooks::execute::{closure#0}
+FNDA:0,sk_core::hooks::test::test_execute_hooks::{closure#0}::logs_contain
+FNDA:0,sk_core::hooks::test::test_execute_hooks::{closure#0}::logs_contain
+FNF:17
+FNH:7
+BRF:0
+BRH:0
+DA:24,45
+DA:25,9
+DA:26,9
+DA:27,6
+DA:28,1
+DA:29,0
+DA:30,2
+DA:32,0
+DA:35,9
+DA:36,7
+DA:38,13
+DA:39,7
+DA:40,7
+DA:41,7
+DA:42,7
+DA:43,7
+DA:44,7
+DA:45,7
+DA:46,6
+DA:47,0
+DA:48,0
+DA:49,0
+DA:50,6
+DA:51,20
+DA:52,6
+DA:53,6
+DA:54,0
+DA:56,6
+DA:57,0
+DA:58,6
+DA:62,6
+DA:63,2
+DA:65,8
+DA:66,9
+LF:34
+LH:27
+end_of_record
+SF:sk-core/src/k8s/lease.rs
+FN:100,sk_core::k8s::lease::try_update_lease
+FN:44,sk_core::k8s::lease::try_claim_lease::{closure#0}
+FN:39,sk_core::k8s::lease::try_claim_lease
+FN:25,sk_core::k8s::lease::build_lease
+FN:147,sk_core::k8s::lease::compute_remaining_lease_time::{closure#1}
+FN:115,sk_core::k8s::lease::try_update_lease_with_clock::{closure#0}
+FN:144,sk_core::k8s::lease::compute_remaining_lease_time::{closure#0}
+FN:144,sk_core::k8s::lease::compute_remaining_lease_time::{closure#0}
+FN:25,sk_core::k8s::lease::build_lease
+FN:115,sk_core::k8s::lease::try_update_lease_with_clock::{closure#0}
+FN:48,sk_core::k8s::lease::try_claim_lease_with_clock
+FN:54,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}
+FN:54,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}
+FN:87,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#1}
+FN:100,sk_core::k8s::lease::try_update_lease
+FN:109,sk_core::k8s::lease::try_update_lease_with_clock
+FN:65,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#0}
+FN:109,sk_core::k8s::lease::try_update_lease_with_clock
+FN:48,sk_core::k8s::lease::try_claim_lease_with_clock
+FN:65,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#0}
+FN:100,sk_core::k8s::lease::try_update_lease
+FN:139,sk_core::k8s::lease::compute_remaining_lease_time
+FN:139,sk_core::k8s::lease::compute_remaining_lease_time
+FN:48,sk_core::k8s::lease::try_claim_lease_with_clock
+FN:54,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}
+FN:65,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#0}
+FN:115,sk_core::k8s::lease::try_update_lease_with_clock::{closure#0}
+FN:65,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#0}
+FN:44,sk_core::k8s::lease::try_claim_lease::{closure#0}
+FN:144,sk_core::k8s::lease::compute_remaining_lease_time::{closure#0}
+FN:54,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}
+FN:39,sk_core::k8s::lease::try_claim_lease
+FN:44,sk_core::k8s::lease::try_claim_lease::{closure#0}
+FN:87,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#1}
+FN:147,sk_core::k8s::lease::compute_remaining_lease_time::{closure#1}
+FN:115,sk_core::k8s::lease::try_update_lease_with_clock::{closure#0}
+FN:39,sk_core::k8s::lease::try_claim_lease
+FN:87,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#1}
+FN:44,sk_core::k8s::lease::try_claim_lease::{closure#0}
+FN:105,sk_core::k8s::lease::try_update_lease::{closure#0}
+FN:109,sk_core::k8s::lease::try_update_lease_with_clock
+FN:105,sk_core::k8s::lease::try_update_lease::{closure#0}
+FN:147,sk_core::k8s::lease::compute_remaining_lease_time::{closure#1}
+FN:87,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#1}
+FN:105,sk_core::k8s::lease::try_update_lease::{closure#0}
+FN:105,sk_core::k8s::lease::try_update_lease::{closure#0}
+FN:25,sk_core::k8s::lease::build_lease
+FN:139,sk_core::k8s::lease::compute_remaining_lease_time
+FNDA:0,sk_core::k8s::lease::try_update_lease
+FNDA:0,sk_core::k8s::lease::try_claim_lease::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_claim_lease
+FNDA:1,sk_core::k8s::lease::build_lease
+FNDA:1,sk_core::k8s::lease::compute_remaining_lease_time::{closure#1}
+FNDA:1,sk_core::k8s::lease::try_update_lease_with_clock::{closure#0}
+FNDA:0,sk_core::k8s::lease::compute_remaining_lease_time::{closure#0}
+FNDA:1,sk_core::k8s::lease::compute_remaining_lease_time::{closure#0}
+FNDA:0,sk_core::k8s::lease::build_lease
+FNDA:0,sk_core::k8s::lease::try_update_lease_with_clock::{closure#0}
+FNDA:1,sk_core::k8s::lease::try_claim_lease_with_clock
+FNDA:0,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#1}
+FNDA:0,sk_core::k8s::lease::try_update_lease
+FNDA:1,sk_core::k8s::lease::try_update_lease_with_clock
+FNDA:0,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_update_lease_with_clock
+FNDA:0,sk_core::k8s::lease::try_claim_lease_with_clock
+FNDA:1,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#0}
+FNDA:1,sk_core::k8s::lease::try_update_lease
+FNDA:1,sk_core::k8s::lease::compute_remaining_lease_time
+FNDA:1,sk_core::k8s::lease::compute_remaining_lease_time
+FNDA:1,sk_core::k8s::lease::try_claim_lease_with_clock
+FNDA:1,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#0}
+FNDA:1,sk_core::k8s::lease::try_update_lease_with_clock::{closure#0}
+FNDA:1,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_claim_lease::{closure#0}
+FNDA:0,sk_core::k8s::lease::compute_remaining_lease_time::{closure#0}
+FNDA:1,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_claim_lease
+FNDA:0,sk_core::k8s::lease::try_claim_lease::{closure#0}
+FNDA:1,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#1}
+FNDA:0,sk_core::k8s::lease::compute_remaining_lease_time::{closure#1}
+FNDA:0,sk_core::k8s::lease::try_update_lease_with_clock::{closure#0}
+FNDA:1,sk_core::k8s::lease::try_claim_lease
+FNDA:0,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#1}
+FNDA:1,sk_core::k8s::lease::try_claim_lease::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_update_lease::{closure#0}
+FNDA:1,sk_core::k8s::lease::try_update_lease_with_clock
+FNDA:0,sk_core::k8s::lease::try_update_lease::{closure#0}
+FNDA:1,sk_core::k8s::lease::compute_remaining_lease_time::{closure#1}
+FNDA:1,sk_core::k8s::lease::try_claim_lease_with_clock::{closure#0}::{closure#1}
+FNDA:1,sk_core::k8s::lease::try_update_lease::{closure#0}
+FNDA:0,sk_core::k8s::lease::try_update_lease::{closure#0}
+FNDA:1,sk_core::k8s::lease::build_lease
+FNDA:0,sk_core::k8s::lease::compute_remaining_lease_time
+FNF:48
+FNH:23
+BRF:0
+BRH:0
+DA:25,100
+DA:26,100
+DA:27,100
+DA:28,100
+DA:29,100
+DA:30,100
+DA:31,100
+DA:32,100
+DA:33,100
+DA:34,100
+DA:35,100
+DA:36,100
+DA:37,100
+DA:39,35
+DA:40,35
+DA:41,35
+DA:42,35
+DA:43,35
+DA:44,35
+DA:45,12
+DA:46,5
+DA:48,39
+DA:49,39
+DA:50,39
+DA:51,39
+DA:52,39
+DA:53,39
+DA:54,39
+DA:55,9
+DA:56,9
+DA:57,9
+DA:58,9
+DA:59,9
+DA:60,9
+DA:61,9
+DA:62,9
+DA:63,9
+DA:64,26
+DA:65,9
+DA:69,6
+DA:70,6
+DA:71,6
+DA:72,6
+DA:73,6
+DA:74,6
+DA:75,6
+DA:76,4
+DA:77,4
+DA:78,2
+DA:79,2
+DA:80,2
+DA:81,2
+DA:85,1
+DA:86,9
+DA:87,9
+DA:88,9
+DA:89,9
+DA:90,9
+DA:92,3
+DA:93,6
+DA:94,2
+DA:96,6
+DA:98,9
+DA:100,14
+DA:101,14
+DA:102,14
+DA:103,14
+DA:104,14
+DA:105,14
+DA:106,8
+DA:107,2
+DA:109,17
+DA:110,17
+DA:111,17
+DA:112,17
+DA:113,17
+DA:114,17
+DA:115,17
+DA:116,5
+DA:117,16
+DA:118,4
+DA:119,1
+DA:121,3
+DA:122,3
+DA:123,3
+DA:124,3
+DA:125,3
+DA:126,3
+DA:127,3
+DA:128,3
+DA:129,3
+DA:130,3
+DA:131,3
+DA:132,3
+DA:133,3
+DA:134,3
+DA:135,6
+DA:136,3
+DA:137,5
+DA:139,13
+DA:140,13
+DA:141,13
+DA:142,13
+DA:143,13
+DA:144,13
+DA:145,13
+DA:146,13
+DA:147,13
+DA:148,13
+DA:149,13
+DA:150,13
+DA:151,1
+DA:152,1
+DA:153,12
+DA:154,12
+DA:155,13
+LF:116
+LH:116
+end_of_record
+SF:sk-cli/src/xray/app.rs
+FN:48,<skctl::xray::app::App>::new
+FN:48,<skctl::xray::app::App>::new
+FN:110,<skctl::xray::app::App>::highlighted_event_index
+FN:110,<skctl::xray::app::App>::highlighted_event_index
+FN:64,<skctl::xray::app::App>::update_state
+FN:58,<skctl::xray::app::App>::rebuild_annotated_trace
+FN:58,<skctl::xray::app::App>::rebuild_annotated_trace
+FN:64,<skctl::xray::app::App>::update_state
+FN:48,<skctl::xray::app::App>::new::{closure#0}
+FN:48,<skctl::xray::app::App>::new::{closure#0}
+FNDA:0,<skctl::xray::app::App>::new
+FNDA:0,<skctl::xray::app::App>::new
+FNDA:0,<skctl::xray::app::App>::highlighted_event_index
+FNDA:1,<skctl::xray::app::App>::highlighted_event_index
+FNDA:0,<skctl::xray::app::App>::update_state
+FNDA:0,<skctl::xray::app::App>::rebuild_annotated_trace
+FNDA:0,<skctl::xray::app::App>::rebuild_annotated_trace
+FNDA:1,<skctl::xray::app::App>::update_state
+FNDA:0,<skctl::xray::app::App>::new::{closure#0}
+FNDA:0,<skctl::xray::app::App>::new::{closure#0}
+FNF:10
+FNH:2
+BRF:0
+BRH:0
+DA:48,0
+DA:49,0
+DA:50,0
+DA:51,0
+DA:52,0
+DA:53,0
+DA:54,0
+DA:56,0
+DA:58,0
+DA:59,0
+DA:60,0
+DA:61,0
+DA:62,0
+DA:64,14
+DA:65,14
+DA:66,14
+DA:67,4
+DA:68,5
+DA:69,5
+DA:71,14
+DA:72,3
+DA:73,3
+DA:74,0
+DA:75,0
+DA:77,3
+DA:78,1
+DA:79,1
+DA:80,1
+DA:81,1
+DA:82,1
+DA:83,1
+DA:85,4
+DA:87,2
+DA:88,2
+DA:89,1
+DA:90,1
+DA:91,1
+DA:92,1
+DA:94,1
+DA:95,1
+DA:96,1
+DA:97,1
+DA:98,1
+DA:99,1
+DA:102,1
+DA:104,0
+DA:107,14
+DA:108,14
+DA:110,17
+DA:111,17
+DA:112,17
+DA:113,17
+LF:52
+LH:36
+end_of_record
+SF:sk-core/src/macros.rs
+FN:23,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<&sk_core::k8s::PodLifecycleData>>::eq
+FN:41,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<sk_core::k8s::PodLifecycleData>>::partial_cmp
+FN:35,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<&sk_core::k8s::PodLifecycleData>>::partial_cmp
+FN:23,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<&sk_core::k8s::PodLifecycleData>>::eq
+FN:29,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<sk_core::k8s::PodLifecycleData>>::eq
+FN:29,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<sk_core::k8s::PodLifecycleData>>::eq
+FN:41,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<sk_core::k8s::PodLifecycleData>>::partial_cmp
+FN:35,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<&sk_core::k8s::PodLifecycleData>>::partial_cmp
+FN:23,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<&sk_core::k8s::PodLifecycleData>>::eq
+FN:29,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<sk_core::k8s::PodLifecycleData>>::eq
+FN:35,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<&sk_core::k8s::PodLifecycleData>>::partial_cmp
+FN:41,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<sk_core::k8s::PodLifecycleData>>::partial_cmp
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<&sk_core::k8s::PodLifecycleData>>::eq
+FNDA:0,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<sk_core::k8s::PodLifecycleData>>::partial_cmp
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<&sk_core::k8s::PodLifecycleData>>::partial_cmp
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<&sk_core::k8s::PodLifecycleData>>::eq
+FNDA:0,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<sk_core::k8s::PodLifecycleData>>::eq
+FNDA:1,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<sk_core::k8s::PodLifecycleData>>::eq
+FNDA:0,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<sk_core::k8s::PodLifecycleData>>::partial_cmp
+FNDA:1,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<&sk_core::k8s::PodLifecycleData>>::partial_cmp
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<&sk_core::k8s::PodLifecycleData>>::eq
+FNDA:1,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialEq<sk_core::k8s::PodLifecycleData>>::eq
+FNDA:0,<sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<&sk_core::k8s::PodLifecycleData>>::partial_cmp
+FNDA:0,<&sk_core::k8s::PodLifecycleData as core::cmp::PartialOrd<sk_core::k8s::PodLifecycleData>>::partial_cmp
+FNF:12
+FNH:4
+BRF:0
+BRH:0
+DA:23,0
+DA:24,0
+DA:25,0
+DA:29,128
+DA:30,128
+DA:31,128
+DA:35,65
+DA:36,65
+DA:37,65
+DA:41,0
+DA:42,0
+DA:43,0
+LF:12
+LH:6
+end_of_record
+SF:sk-store/src/filter.rs
+FN:18,sk_store::filter::filter_event::{closure#1}
+FN:39,sk_store::filter::obj_matches_filter::{closure#1}
+FN:39,sk_store::filter::obj_matches_filter::{closure#1}
+FN:6,sk_store::filter::filter_event
+FN:43,sk_store::filter::obj_matches_filter::{closure#2}
+FN:34,sk_store::filter::obj_matches_filter::{closure#0}
+FN:30,sk_store::filter::obj_matches_filter
+FN:39,sk_store::filter::obj_matches_filter::{closure#1}
+FN:34,sk_store::filter::obj_matches_filter::{closure#0}
+FN:18,sk_store::filter::filter_event::{closure#1}
+FN:39,sk_store::filter::obj_matches_filter::{closure#1}::{closure#0}
+FN:39,sk_store::filter::obj_matches_filter::{closure#1}::{closure#0}
+FN:43,sk_store::filter::obj_matches_filter::{closure#2}
+FN:30,sk_store::filter::obj_matches_filter
+FN:34,sk_store::filter::obj_matches_filter::{closure#0}
+FN:43,sk_store::filter::obj_matches_filter::{closure#2}
+FN:39,sk_store::filter::obj_matches_filter::{closure#1}::{closure#0}
+FN:30,sk_store::filter::obj_matches_filter
+FN:12,sk_store::filter::filter_event::{closure#0}
+FN:18,sk_store::filter::filter_event::{closure#1}
+FN:12,sk_store::filter::filter_event::{closure#0}
+FN:12,sk_store::filter::filter_event::{closure#0}
+FN:6,sk_store::filter::filter_event
+FN:6,sk_store::filter::filter_event
+FNDA:0,sk_store::filter::filter_event::{closure#1}
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#1}
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#1}
+FNDA:1,sk_store::filter::filter_event
+FNDA:1,sk_store::filter::obj_matches_filter::{closure#2}
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#0}
+FNDA:0,sk_store::filter::obj_matches_filter
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#1}
+FNDA:1,sk_store::filter::obj_matches_filter::{closure#0}
+FNDA:1,sk_store::filter::filter_event::{closure#1}
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#1}::{closure#0}
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#1}::{closure#0}
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#2}
+FNDA:1,sk_store::filter::obj_matches_filter
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#0}
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#2}
+FNDA:0,sk_store::filter::obj_matches_filter::{closure#1}::{closure#0}
+FNDA:0,sk_store::filter::obj_matches_filter
+FNDA:1,sk_store::filter::filter_event::{closure#0}
+FNDA:0,sk_store::filter::filter_event::{closure#1}
+FNDA:0,sk_store::filter::filter_event::{closure#0}
+FNDA:0,sk_store::filter::filter_event::{closure#0}
+FNDA:0,sk_store::filter::filter_event
+FNDA:0,sk_store::filter::filter_event
+FNF:24
+FNH:6
+BRF:0
+BRH:0
+DA:6,30
+DA:7,30
+DA:8,30
+DA:9,30
+DA:10,30
+DA:11,30
+DA:12,64
+DA:13,30
+DA:14,30
+DA:15,30
+DA:16,30
+DA:17,30
+DA:18,30
+DA:19,30
+DA:20,30
+DA:21,30
+DA:22,30
+DA:23,30
+DA:24,4
+DA:25,26
+DA:26,26
+DA:27,26
+DA:28,30
+DA:30,81
+DA:31,81
+DA:32,81
+DA:33,81
+DA:34,81
+DA:35,78
+DA:36,78
+DA:37,78
+DA:38,78
+DA:39,78
+DA:43,78
+DA:44,81
+LF:35
+LH:35
+end_of_record
+SF:sk-ctrl/src/cert_manager.rs
+FN:25,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FN:44,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FN:25,<sk_ctrl::cert_manager::CertificateIssuerRef as schemars::JsonSchema>::json_schema::{closure#1}
+FN:25,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:25,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::StrRead>>
+FN:66,sk_ctrl::cert_manager::api_resource
+FN:54,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FN:25,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::StrRead>>
+FN:54,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:54,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::StrRead>>
+FN:25,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::StrRead>>
+FN:44,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:44,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::StrRead>>
+FN:25,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:54,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:35,<sk_ctrl::cert_manager::CertificateSecretTemplate as schemars::JsonSchema>::json_schema::{closure#1}
+FN:35,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FN:44,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FN:44,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::StrRead>>
+FN:62,sk_ctrl::cert_manager::api_version
+FN:44,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:54,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::StrRead>>
+FN:76,sk_ctrl::cert_manager::create_certificate_if_not_present
+FN:35,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:25,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:25,<sk_ctrl::cert_manager::CertificateIssuerRef as schemars::JsonSchema>::json_schema::{closure#0}
+FN:35,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:35,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:54,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::StrRead>>
+FN:44,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:35,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::StrRead>>
+FN:80,sk_ctrl::cert_manager::create_certificate_if_not_present::{closure#0}
+FN:35,<sk_ctrl::cert_manager::CertificateSecretTemplate as schemars::JsonSchema>::json_schema::{closure#0}
+FN:44,<sk_ctrl::cert_manager::PartialCertificateSpec as schemars::JsonSchema>::json_schema::{closure#0}
+FN:54,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FN:54,<sk_ctrl::cert_manager::PartialCertificateStatus as schemars::JsonSchema>::json_schema::{closure#0}
+FN:44,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::StrRead>>
+FN:25,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FN:35,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FN:35,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::StrRead>>
+FN:35,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::StrRead>>
+FN:54,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FNDA:0,<sk_ctrl::cert_manager::CertificateIssuerRef as schemars::JsonSchema>::json_schema::{closure#1}
+FNDA:0,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::StrRead>>
+FNDA:0,sk_ctrl::cert_manager::api_resource
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::StrRead>>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::StrRead>>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::StrRead>>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::StrRead>>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_ctrl::cert_manager::CertificateSecretTemplate as schemars::JsonSchema>::json_schema::{closure#1}
+FNDA:0,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::StrRead>>
+FNDA:0,sk_ctrl::cert_manager::api_version
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::StrRead>>
+FNDA:0,sk_ctrl::cert_manager::create_certificate_if_not_present
+FNDA:0,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<sk_ctrl::cert_manager::CertificateIssuerRef as schemars::JsonSchema>::json_schema::{closure#0}
+FNDA:0,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::StrRead>>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::StrRead>>
+FNDA:0,sk_ctrl::cert_manager::create_certificate_if_not_present::{closure#0}
+FNDA:0,<sk_ctrl::cert_manager::CertificateSecretTemplate as schemars::JsonSchema>::json_schema::{closure#0}
+FNDA:0,<sk_ctrl::cert_manager::PartialCertificateSpec as schemars::JsonSchema>::json_schema::{closure#0}
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FNDA:0,<sk_ctrl::cert_manager::PartialCertificateStatus as schemars::JsonSchema>::json_schema::{closure#0}
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateSpec as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<serde_json::de::MapAccess<serde_json::read::StrRead>>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateIssuerRef as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::StrRead>>
+FNDA:0,<<sk_ctrl::cert_manager::CertificateSecretTemplate as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<serde_json::de::MapKey<serde_json::read::StrRead>>
+FNDA:0,<<sk_ctrl::cert_manager::PartialCertificateStatus as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNF:42
+FNH:0
+BRF:0
+BRH:0
+DA:62,0
+DA:63,0
+DA:64,0
+DA:66,0
+DA:67,0
+DA:68,0
+DA:69,0
+DA:70,0
+DA:71,0
+DA:72,0
+DA:73,0
+DA:74,0
+DA:76,0
+DA:77,0
+DA:78,0
+DA:79,0
+DA:80,0
+DA:81,0
+DA:82,0
+DA:83,0
+DA:84,0
+DA:85,0
+DA:86,0
+DA:87,0
+DA:88,0
+DA:89,0
+DA:90,0
+DA:93,0
+DA:94,0
+DA:95,0
+DA:96,0
+DA:97,0
+DA:98,0
+DA:99,0
+DA:100,0
+DA:101,0
+DA:102,0
+DA:103,0
+DA:104,0
+DA:105,0
+DA:106,0
+DA:107,0
+DA:108,0
+DA:109,0
+DA:110,0
+DA:111,0
+DA:112,0
+DA:113,0
+DA:114,0
+DA:115,0
+DA:117,0
+DA:118,0
+LF:52
+LH:0
+end_of_record
+SF:sk-cli/src/run.rs
+FN:125,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#12}
+FN:19,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:171,skctl::run::cmd::{closure#0}::{closure#0}
+FN:82,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#7}
+FN:134,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#13}
+FN:90,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#8}
+FN:90,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#8}
+FN:60,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FN:35,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:171,skctl::run::cmd::{closure#0}::{closure#0}
+FN:52,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FN:107,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#10}
+FN:82,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#7}
+FN:98,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#9}
+FN:98,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#9}
+FN:116,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#11}
+FN:157,skctl::run::cmd::{closure#0}
+FN:116,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#11}
+FN:69,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#5}
+FN:69,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#5}
+FN:52,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FN:125,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#12}
+FN:69,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#5}
+FN:43,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:19,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:43,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:82,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#7}
+FN:82,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#7}
+FN:90,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#8}
+FN:35,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:72,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#6}
+FN:35,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:60,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FN:134,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#13}
+FN:98,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#9}
+FN:125,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#12}
+FN:19,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:52,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FN:35,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:60,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FN:52,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FN:134,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#13}
+FN:43,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:90,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#8}
+FN:72,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#6}
+FN:72,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#6}
+FN:157,skctl::run::cmd
+FN:107,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#10}
+FN:69,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#5}
+FN:157,skctl::run::cmd
+FN:43,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:134,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#13}
+FN:19,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:98,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#9}
+FN:107,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#10}
+FN:157,skctl::run::cmd::{closure#0}
+FN:72,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#6}
+FN:60,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FN:116,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#11}
+FN:125,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#12}
+FN:107,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#10}
+FN:116,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#11}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#12}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::run::cmd::{closure#0}::{closure#0}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#7}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#13}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#8}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#8}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,skctl::run::cmd::{closure#0}::{closure#0}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#10}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#7}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#9}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#9}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#11}
+FNDA:0,skctl::run::cmd::{closure#0}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#11}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#5}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#5}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#12}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#5}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#7}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#7}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#8}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#6}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#13}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#9}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#12}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#13}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#8}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#6}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#6}
+FNDA:0,skctl::run::cmd
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#10}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#5}
+FNDA:0,skctl::run::cmd
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#13}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#9}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#10}
+FNDA:0,skctl::run::cmd::{closure#0}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#6}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#11}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#12}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#10}
+FNDA:0,<skctl::run::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#11}
+FNF:62
+FNH:0
+BRF:0
+BRH:0
+DA:19,0
+DA:35,0
+DA:43,0
+DA:52,0
+DA:60,0
+DA:69,0
+DA:72,0
+DA:82,0
+DA:90,0
+DA:98,0
+DA:107,0
+DA:116,0
+DA:125,0
+DA:134,0
+DA:157,0
+DA:158,0
+DA:159,0
+DA:160,0
+DA:161,0
+DA:162,0
+DA:163,0
+DA:164,0
+DA:165,0
+DA:166,0
+DA:167,0
+DA:168,0
+DA:169,0
+DA:170,0
+DA:171,0
+DA:172,0
+DA:173,0
+DA:174,0
+DA:175,0
+DA:176,0
+DA:177,0
+DA:179,0
+DA:180,0
+DA:181,0
+DA:182,0
+DA:183,0
+DA:184,0
+DA:185,0
+DA:186,0
+DA:187,0
+DA:188,0
+DA:189,0
+DA:190,0
+DA:191,0
+DA:192,0
+DA:193,0
+DA:194,0
+DA:195,0
+DA:196,0
+DA:197,0
+DA:198,0
+DA:200,0
+DA:201,0
+LF:57
+LH:0
+end_of_record
+SF:sk-core/src/k8s/container_state.rs
+FN:11,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::start_ts
+FN:33,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::end_ts
+FN:11,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::start_ts
+FN:33,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::end_ts
+FN:33,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::end_ts
+FN:11,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::start_ts
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::start_ts
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::end_ts
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::start_ts
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::end_ts
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::end_ts
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::container_state::ContainerState as sk_core::k8s::StartEndTimeable>::start_ts
+FNF:6
+FNH:4
+BRF:0
+BRH:0
+DA:11,80
+DA:12,1
+DA:13,43
+DA:14,43
+DA:15,42
+DA:16,1
+DA:19,35
+DA:20,35
+DA:21,34
+DA:23,1
+DA:24,1
+DA:28,1
+DA:29,1
+DA:31,80
+DA:33,80
+DA:34,1
+DA:35,43
+DA:36,35
+DA:37,35
+DA:38,34
+DA:40,1
+DA:41,1
+DA:45,1
+DA:46,1
+DA:48,80
+LF:25
+LH:25
+end_of_record
+SF:sk-cli/src/validation/summary.rs
+FN:16,<skctl::validation::summary::ValidationSummary as core::fmt::Display>::fmt
+FN:16,<skctl::validation::summary::ValidationSummary as core::fmt::Display>::fmt
+FN:23,<skctl::validation::summary::ValidationSummary as core::fmt::Display>::fmt::{closure#0}
+FN:23,<skctl::validation::summary::ValidationSummary as core::fmt::Display>::fmt::{closure#0}
+FNDA:0,<skctl::validation::summary::ValidationSummary as core::fmt::Display>::fmt
+FNDA:0,<skctl::validation::summary::ValidationSummary as core::fmt::Display>::fmt
+FNDA:0,<skctl::validation::summary::ValidationSummary as core::fmt::Display>::fmt::{closure#0}
+FNDA:0,<skctl::validation::summary::ValidationSummary as core::fmt::Display>::fmt::{closure#0}
+FNF:4
+FNH:0
+BRF:0
+BRH:0
+DA:16,0
+DA:17,0
+DA:18,0
+DA:19,0
+DA:20,0
+DA:21,0
+DA:22,0
+DA:23,0
+DA:24,0
+DA:25,0
+DA:26,0
+DA:27,0
+DA:30,0
+DA:31,0
+DA:32,0
+DA:33,0
+DA:34,0
+DA:35,0
+DA:36,0
+LF:19
+LH:0
+end_of_record
+SF:sk-core/src/k8s/mod.rs
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::VariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<_>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::VariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::expecting
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::expecting
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::VariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::VariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<_>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::VariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::UnitVariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::UnitVariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_json::de::Deserializer<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<_>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_json::de::Deserializer<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_json::de::Deserializer<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::UnitVariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::expecting
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::UnitVariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::UnitVariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::VariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<_>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::UnitVariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FN:43,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::VariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<_>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::VariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::VariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::VariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_bytes::<rmp_serde::decode::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<_>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde_json::de::SeqAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::VariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::UnitVariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::UnitVariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_json::de::Deserializer<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<_>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_u64::<rmp_serde::decode::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_json::de::Deserializer<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut serde_json::de::Deserializer<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::UnitVariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::UnitVariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::expecting
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<serde::de::value::SeqDeserializer<core::iter::adapters::copied::Copied<core::slice::iter::Iter<u8>>, rmp_serde::decode::Error>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<&mut rmp_serde::decode::SeqAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<serde_json::error::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::UnitVariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::__Visitor as serde::de::Visitor>::visit_seq::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<serde_json::de::VariantAccess<serde_json::read::IoRead<std::io::buffered::bufreader::BufReader<std::fs::File>>>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__FieldVisitor as serde::de::Visitor>::visit_str::<rmp_serde::decode::Error>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<_>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_enum::<rmp_serde::decode::UnitVariantAccess<rmp_serde::decode::ReadRefReader<[u8]>, rmp_serde::config::DefaultConfig>>
+FNDA:0,<<sk_core::k8s::PodLifecycleData as serde::de::Deserialize>::deserialize::__Field as serde::de::Deserialize>::deserialize::<&mut rmp_serde::decode::Deserializer<rmp_serde::decode::ReadRefReader<[u8]>>>
+FNF:66
+FNH:0
+BRF:0
+BRH:0
+LF:0
+LH:0
+end_of_record
+SF:sk-store/src/watchers/pod_watcher.rs
+FN:159,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied
+FN:130,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data
+FN:105,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted::{closure#0}
+FN:71,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied::{closure#0}
+FN:159,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied::{closure#0}
+FN:136,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data::{closure#0}
+FN:62,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream::{closure#0}
+FN:136,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data::{closure#0}
+FN:159,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied
+FN:66,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied
+FN:169,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted
+FN:98,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted
+FN:184,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}
+FN:105,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted::{closure#0}
+FN:217,<sk_store::watchers::pod_watcher::PodHandler>::new_from_parts
+FN:55,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream
+FN:66,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied
+FN:159,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied::{closure#0}
+FN:169,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted::{closure#0}
+FN:224,<sk_store::watchers::pod_watcher::PodHandler>::get_owned_pod_lifecycle
+FN:184,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized
+FN:66,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied
+FN:71,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied::{closure#0}
+FN:159,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied
+FN:217,<sk_store::watchers::pod_watcher::PodHandler>::new_from_parts
+FN:184,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}
+FN:184,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}
+FN:169,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted
+FN:62,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream::{closure#0}
+FN:159,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied::{closure#0}
+FN:55,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream
+FN:130,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data
+FN:55,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream
+FN:71,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied::{closure#0}
+FN:98,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted
+FN:184,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized
+FN:98,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted
+FN:105,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted::{closure#0}
+FN:169,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted::{closure#0}
+FN:184,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized
+FN:169,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted
+FN:224,<sk_store::watchers::pod_watcher::PodHandler>::get_owned_pod_lifecycle
+FN:62,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream::{closure#0}
+FN:130,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data
+FN:169,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted::{closure#0}
+FN:136,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted::{closure#0}
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied::{closure#0}
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream::{closure#0}
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data::{closure#0}
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted::{closure#0}
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler>::new_from_parts
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied::{closure#0}
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted::{closure#0}
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler>::get_owned_pod_lifecycle
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::new_from_parts
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::applied::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_applied::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::handle_pod_deleted::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::initialized
+FNDA:1,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::get_owned_pod_lifecycle
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::new_with_stream::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler as sk_store::watchers::EventHandler<k8s_openapi::v1_27::api::core::v1::pod::Pod>>::deleted::{closure#0}
+FNDA:0,<sk_store::watchers::pod_watcher::PodHandler>::store_pod_lifecycle_data::{closure#0}
+FNF:46
+FNH:14
+BRF:0
+BRH:0
+DA:55,0
+DA:56,0
+DA:57,0
+DA:58,0
+DA:59,0
+DA:60,0
+DA:61,0
+DA:62,0
+DA:63,0
+DA:64,0
+DA:66,8
+DA:67,8
+DA:68,8
+DA:69,8
+DA:70,8
+DA:71,8
+DA:72,8
+DA:73,8
+DA:74,8
+DA:75,8
+DA:76,8
+DA:77,8
+DA:78,8
+DA:79,8
+DA:80,8
+DA:81,8
+DA:82,3
+DA:83,3
+DA:84,0
+DA:85,5
+DA:86,2
+DA:87,0
+DA:90,3
+DA:92,8
+DA:93,8
+DA:98,7
+DA:99,7
+DA:100,7
+DA:101,7
+DA:102,7
+DA:103,7
+DA:104,7
+DA:105,7
+DA:106,7
+DA:107,7
+DA:108,7
+DA:109,7
+DA:110,7
+DA:111,7
+DA:112,2
+DA:113,5
+DA:117,5
+DA:120,2
+DA:121,2
+DA:123,3
+DA:126,5
+DA:127,0
+DA:128,7
+DA:130,8
+DA:131,8
+DA:132,8
+DA:133,8
+DA:134,8
+DA:135,8
+DA:136,8
+DA:141,8
+DA:142,2
+DA:143,5
+DA:144,1
+DA:147,7
+DA:148,7
+DA:149,8
+DA:159,6
+DA:160,6
+DA:161,6
+DA:162,6
+DA:169,6
+DA:170,6
+DA:171,6
+DA:172,6
+DA:173,6
+DA:174,6
+DA:175,6
+DA:176,6
+DA:177,6
+DA:184,1
+DA:185,1
+DA:186,1
+DA:187,1
+DA:188,1
+DA:189,1
+DA:190,1
+DA:191,3
+DA:192,2
+DA:193,2
+DA:194,2
+DA:195,2
+DA:196,2
+DA:197,0
+DA:198,2
+DA:199,1
+DA:200,1
+DA:201,3
+DA:202,1
+DA:203,1
+DA:204,2
+DA:205,2
+DA:206,1
+DA:207,1
+DA:208,1
+DA:209,1
+DA:210,1
+DA:211,1
+DA:212,1
+LF:114
+LH:100
+end_of_record
+SF:sk-cli/src/validation/validation_store.rs
+FN:80,<skctl::validation::validation_store::ValidationStore>::print_list
+FN:105,<skctl::validation::validation_store::ValidationStore>::register
+FN:110,<skctl::validation::validation_store::ValidationStore>::register_with_code
+FN:69,<skctl::validation::validation_store::ValidationStore>::print
+FN:25,<skctl::validation::validation_store::ValidationStore>::validate_trace
+FN:87,<skctl::validation::validation_store::ValidationStore>::print_table
+FN:65,<skctl::validation::validation_store::ValidationStore>::lookup
+FN:69,<skctl::validation::validation_store::ValidationStore>::print
+FN:65,<skctl::validation::validation_store::ValidationStore>::lookup
+FN:110,<skctl::validation::validation_store::ValidationStore>::register_with_code
+FN:87,<skctl::validation::validation_store::ValidationStore>::print_table
+FN:80,<skctl::validation::validation_store::ValidationStore>::print_list
+FN:57,<skctl::validation::validation_store::ValidationStore>::explain
+FN:96,<skctl::validation::validation_store::ValidationStore>::new
+FN:57,<skctl::validation::validation_store::ValidationStore>::explain
+FN:25,<skctl::validation::validation_store::ValidationStore>::validate_trace
+FN:105,<skctl::validation::validation_store::ValidationStore>::register
+FN:96,<skctl::validation::validation_store::ValidationStore>::new
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::print_list
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::register
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::register_with_code
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::print
+FNDA:1,<skctl::validation::validation_store::ValidationStore>::validate_trace
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::print_table
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::lookup
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::print
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::lookup
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::register_with_code
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::print_table
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::print_list
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::explain
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::new
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::explain
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::validate_trace
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::register
+FNDA:0,<skctl::validation::validation_store::ValidationStore>::new
+FNF:18
+FNH:1
+BRF:0
+BRH:0
+DA:25,17
+DA:26,17
+DA:27,17
+DA:28,17
+DA:30,17
+DA:31,17
+DA:33,18
+DA:34,18
+DA:35,17
+DA:36,17
+DA:37,17
+DA:39,18
+DA:40,16
+DA:41,2
+DA:43,2
+DA:44,1
+DA:47,1
+DA:48,0
+DA:49,0
+DA:51,1
+DA:54,17
+DA:55,17
+DA:57,0
+DA:58,0
+DA:59,0
+DA:60,0
+DA:61,0
+DA:62,0
+DA:63,0
+DA:65,0
+DA:66,0
+DA:67,0
+DA:69,0
+DA:70,0
+DA:71,0
+DA:72,0
+DA:73,0
+DA:74,0
+DA:77,0
+DA:78,0
+DA:80,0
+DA:81,0
+DA:82,0
+DA:83,0
+DA:84,0
+DA:85,0
+DA:87,0
+DA:88,0
+DA:89,0
+DA:90,0
+DA:91,0
+DA:92,0
+DA:93,0
+DA:94,0
+DA:96,0
+DA:97,0
+DA:98,0
+DA:99,0
+DA:100,0
+DA:101,0
+DA:102,0
+DA:103,0
+DA:105,0
+DA:106,0
+DA:107,0
+DA:108,0
+DA:110,0
+DA:111,0
+DA:112,0
+LF:69
+LH:20
+end_of_record
+SF:sk-ctrl/src/controller.rs
+FN:121,sk_ctrl::controller::setup_simulation::{closure#0}
+FN:89,sk_ctrl::controller::fetch_driver_state::{closure#0}::{closure#2}
+FN:54,sk_ctrl::controller::setup_sim_metaroot
+FN:228,sk_ctrl::controller::reconcile::{closure#0}
+FN:282,sk_ctrl::controller::error_policy
+FN:291,sk_ctrl::controller::error_policy::{closure#0}
+FN:255,sk_ctrl::controller::reconcile::{closure#0}::{closure#0}::{closure#1}
+FN:83,sk_ctrl::controller::fetch_driver_state::{closure#0}::{closure#0}
+FN:76,sk_ctrl::controller::fetch_driver_state::{closure#0}
+FN:85,sk_ctrl::controller::fetch_driver_state::{closure#0}::{closure#1}
+FN:116,sk_ctrl::controller::setup_simulation
+FN:54,sk_ctrl::controller::setup_sim_metaroot::{closure#0}
+FN:60,sk_ctrl::controller::setup_sim_metaroot::{closure#0}::{closure#0}
+FN:228,sk_ctrl::controller::reconcile::{closure#0}::{closure#0}
+FN:215,sk_ctrl::controller::cleanup_simulation::{closure#0}
+FN:232,sk_ctrl::controller::reconcile::{closure#0}::{closure#0}::{closure#0}
+FN:215,sk_ctrl::controller::cleanup_simulation
+FN:71,sk_ctrl::controller::fetch_driver_state
+FN:258,sk_ctrl::controller::reconcile::{closure#0}::{closure#0}::{closure#2}
+FNDA:1,sk_ctrl::controller::setup_simulation::{closure#0}
+FNDA:0,sk_ctrl::controller::fetch_driver_state::{closure#0}::{closure#2}
+FNDA:0,sk_ctrl::controller::setup_sim_metaroot
+FNDA:0,sk_ctrl::controller::reconcile::{closure#0}
+FNDA:0,sk_ctrl::controller::error_policy
+FNDA:0,sk_ctrl::controller::error_policy::{closure#0}
+FNDA:0,sk_ctrl::controller::reconcile::{closure#0}::{closure#0}::{closure#1}
+FNDA:0,sk_ctrl::controller::fetch_driver_state::{closure#0}::{closure#0}
+FNDA:1,sk_ctrl::controller::fetch_driver_state::{closure#0}
+FNDA:1,sk_ctrl::controller::fetch_driver_state::{closure#0}::{closure#1}
+FNDA:1,sk_ctrl::controller::setup_simulation
+FNDA:0,sk_ctrl::controller::setup_sim_metaroot::{closure#0}
+FNDA:0,sk_ctrl::controller::setup_sim_metaroot::{closure#0}::{closure#0}
+FNDA:0,sk_ctrl::controller::reconcile::{closure#0}::{closure#0}
+FNDA:1,sk_ctrl::controller::cleanup_simulation::{closure#0}
+FNDA:0,sk_ctrl::controller::reconcile::{closure#0}::{closure#0}::{closure#0}
+FNDA:1,sk_ctrl::controller::cleanup_simulation
+FNDA:1,sk_ctrl::controller::fetch_driver_state
+FNDA:0,sk_ctrl::controller::reconcile::{closure#0}::{closure#0}::{closure#2}
+FNF:19
+FNH:7
+BRF:0
+BRH:0
+DA:54,0
+DA:55,0
+DA:56,0
+DA:58,0
+DA:59,0
+DA:60,0
+DA:62,0
+DA:64,0
+DA:71,7
+DA:72,7
+DA:73,7
+DA:74,7
+DA:75,7
+DA:76,7
+DA:77,7
+DA:78,7
+DA:80,28
+DA:81,4
+DA:82,4
+DA:83,3
+DA:84,2
+DA:85,5
+DA:86,5
+DA:87,5
+DA:89,2
+DA:90,2
+DA:91,1
+DA:93,1
+DA:95,1
+DA:96,1
+DA:97,3
+DA:99,7
+DA:104,12
+DA:105,3
+DA:106,1
+DA:107,1
+DA:109,0
+DA:111,2
+DA:113,5
+DA:114,7
+DA:116,5
+DA:117,5
+DA:118,5
+DA:119,5
+DA:120,5
+DA:121,5
+DA:122,5
+DA:124,16
+DA:127,5
+DA:128,5
+DA:129,20
+DA:130,1
+DA:131,4
+DA:132,4
+DA:133,4
+DA:134,8
+DA:135,1
+DA:136,1
+DA:137,2
+DA:138,3
+DA:141,4
+DA:142,4
+DA:143,3
+DA:144,3
+DA:145,3
+DA:146,3
+DA:147,3
+DA:148,6
+DA:150,1
+DA:151,1
+DA:152,2
+DA:154,2
+DA:155,2
+DA:156,1
+DA:157,1
+DA:161,1
+DA:164,4
+DA:165,2
+DA:166,2
+DA:167,2
+DA:168,2
+DA:169,2
+DA:170,2
+DA:171,4
+DA:172,2
+DA:173,2
+DA:174,4
+DA:175,0
+DA:177,2
+DA:178,0
+DA:179,2
+DA:181,2
+DA:182,2
+DA:183,2
+DA:184,2
+DA:185,2
+DA:186,2
+DA:187,4
+DA:188,2
+DA:190,0
+DA:191,0
+DA:193,2
+DA:194,2
+DA:195,2
+DA:196,2
+DA:197,2
+DA:198,4
+DA:199,2
+DA:200,2
+DA:201,4
+DA:202,0
+DA:205,2
+DA:206,4
+DA:207,2
+DA:208,2
+DA:209,4
+DA:210,0
+DA:212,2
+DA:213,5
+DA:215,1
+DA:216,1
+DA:217,1
+DA:218,1
+DA:219,4
+DA:220,0
+DA:221,1
+DA:223,1
+DA:224,0
+DA:225,1
+DA:226,1
+DA:228,0
+DA:232,0
+DA:255,0
+DA:258,0
+DA:282,0
+DA:284,0
+DA:285,0
+DA:287,0
+DA:290,0
+DA:291,0
+DA:292,0
+DA:293,0
+DA:294,0
+DA:295,0
+DA:296,0
+DA:297,0
+DA:298,0
+DA:299,0
+DA:300,0
+DA:301,0
+DA:302,0
+DA:304,0
+DA:305,0
+LF:153
+LH:113
+end_of_record
+SF:sk-cli/src/snapshot.rs
+FN:45,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:45,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:45,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:37,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:48,skctl::snapshot::cmd
+FN:37,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:48,skctl::snapshot::cmd
+FN:45,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:29,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:29,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:29,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:48,skctl::snapshot::cmd::{closure#0}
+FN:37,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:37,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:48,skctl::snapshot::cmd::{closure#0}
+FN:29,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,skctl::snapshot::cmd
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,skctl::snapshot::cmd
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::snapshot::cmd::{closure#0}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,skctl::snapshot::cmd::{closure#0}
+FNDA:0,<skctl::snapshot::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNF:16
+FNH:0
+BRF:0
+BRH:0
+DA:29,0
+DA:37,0
+DA:45,0
+DA:48,0
+DA:49,0
+DA:50,0
+DA:52,0
+DA:53,0
+DA:54,0
+DA:55,0
+DA:56,0
+DA:57,0
+DA:58,0
+DA:59,0
+DA:60,0
+DA:61,0
+DA:62,0
+DA:63,0
+DA:64,0
+DA:67,0
+DA:68,0
+DA:69,0
+DA:72,0
+DA:73,0
+DA:74,0
+DA:75,0
+DA:76,0
+DA:77,0
+DA:79,0
+DA:80,0
+DA:81,0
+DA:82,0
+DA:83,0
+DA:85,0
+DA:86,0
+DA:87,0
+DA:89,0
+DA:90,0
+DA:91,0
+LF:39
+LH:0
+end_of_record
+SF:sk-cli/src/validation/rules/service_account_missing.rs
+FN:82,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}
+FN:112,skctl::validation::rules::service_account_missing::construct_add_svc_account_patch
+FN:132,skctl::validation::rules::service_account_missing::validator
+FN:109,skctl::validation::rules::service_account_missing::construct_remove_svc_account_ref_patch
+FN:59,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::check_next_event
+FN:116,skctl::validation::rules::service_account_missing::construct_add_svc_account_patch
+FN:105,skctl::validation::rules::service_account_missing::construct_remove_svc_account_ref_patch
+FN:59,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::check_next_event
+FN:128,skctl::validation::rules::service_account_missing::validator
+FN:112,skctl::validation::rules::service_account_missing::construct_remove_svc_account_ref_patch::{closure#0}
+FN:40,<skctl::validation::rules::service_account_missing::ServiceAccountMissing>::record_service_accounts
+FN:100,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::reset
+FN:40,<skctl::validation::rules::service_account_missing::ServiceAccountMissing>::record_service_accounts
+FN:82,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}
+FN:108,skctl::validation::rules::service_account_missing::construct_remove_svc_account_ref_patch::{closure#0}
+FN:104,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::reset
+FNDA:1,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}
+FNDA:0,skctl::validation::rules::service_account_missing::construct_add_svc_account_patch
+FNDA:0,skctl::validation::rules::service_account_missing::validator
+FNDA:1,skctl::validation::rules::service_account_missing::construct_remove_svc_account_ref_patch
+FNDA:1,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::check_next_event
+FNDA:1,skctl::validation::rules::service_account_missing::construct_add_svc_account_patch
+FNDA:0,skctl::validation::rules::service_account_missing::construct_remove_svc_account_ref_patch
+FNDA:0,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::check_next_event
+FNDA:0,skctl::validation::rules::service_account_missing::validator
+FNDA:1,skctl::validation::rules::service_account_missing::construct_remove_svc_account_ref_patch::{closure#0}
+FNDA:0,<skctl::validation::rules::service_account_missing::ServiceAccountMissing>::record_service_accounts
+FNDA:0,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::reset
+FNDA:1,<skctl::validation::rules::service_account_missing::ServiceAccountMissing>::record_service_accounts
+FNDA:0,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::check_next_event::{closure#0}
+FNDA:0,skctl::validation::rules::service_account_missing::construct_remove_svc_account_ref_patch::{closure#0}
+FNDA:1,<skctl::validation::rules::service_account_missing::ServiceAccountMissing as skctl::validation::validator::Diagnostic>::reset
+FNF:16
+FNH:7
+BRF:0
+BRH:0
+DA:40,9
+DA:41,18
+DA:42,9
+DA:43,9
+DA:44,3
+DA:45,6
+DA:46,0
+DA:48,10
+DA:49,1
+DA:50,1
+DA:51,1
+DA:52,1
+DA:53,0
+DA:55,9
+DA:59,9
+DA:60,9
+DA:61,9
+DA:62,9
+DA:63,9
+DA:64,9
+DA:65,9
+DA:66,9
+DA:67,9
+DA:68,9
+DA:69,9
+DA:70,6
+DA:71,6
+DA:72,6
+DA:73,6
+DA:74,6
+DA:82,8
+DA:83,0
+DA:84,0
+DA:85,6
+DA:86,6
+DA:87,6
+DA:88,6
+DA:89,4
+DA:90,4
+DA:91,4
+DA:92,4
+DA:93,4
+DA:94,4
+DA:95,4
+DA:96,4
+DA:97,0
+DA:98,3
+DA:100,0
+DA:101,9
+DA:102,9
+DA:104,1
+DA:105,1
+DA:106,1
+DA:107,0
+DA:108,0
+DA:109,4
+DA:110,4
+DA:111,4
+DA:112,8
+DA:113,4
+DA:114,4
+DA:115,0
+DA:116,4
+DA:117,4
+DA:118,4
+DA:119,4
+DA:120,4
+DA:121,4
+DA:122,4
+DA:123,4
+DA:124,4
+DA:125,4
+DA:126,4
+DA:127,4
+DA:128,4
+DA:129,4
+DA:130,4
+DA:131,0
+DA:132,0
+DA:133,0
+DA:134,0
+DA:135,0
+DA:136,0
+DA:137,0
+DA:138,0
+DA:139,0
+LF:86
+LH:68
+end_of_record
+SF:sk-core/src/jsonutils.rs
+FN:12,<sk_core::jsonutils::HashableJsonValue as core::hash::Hash>::hash::<std::hash::random::DefaultHasher>
+FN:42,sk_core::jsonutils::hash
+FN:42,sk_core::jsonutils::hash
+FN:33,sk_core::jsonutils::hash_option
+FN:42,sk_core::jsonutils::hash
+FN:12,<sk_core::jsonutils::HashableJsonValue as core::hash::Hash>::hash::<_>
+FN:12,<sk_core::jsonutils::HashableJsonValue as core::hash::Hash>::hash::<_>
+FN:33,sk_core::jsonutils::hash_option
+FN:33,sk_core::jsonutils::hash_option
+FNDA:1,<sk_core::jsonutils::HashableJsonValue as core::hash::Hash>::hash::<std::hash::random::DefaultHasher>
+FNDA:0,sk_core::jsonutils::hash
+FNDA:0,sk_core::jsonutils::hash
+FNDA:1,sk_core::jsonutils::hash_option
+FNDA:1,sk_core::jsonutils::hash
+FNDA:0,<sk_core::jsonutils::HashableJsonValue as core::hash::Hash>::hash::<_>
+FNDA:0,<sk_core::jsonutils::HashableJsonValue as core::hash::Hash>::hash::<_>
+FNDA:0,sk_core::jsonutils::hash_option
+FNDA:0,sk_core::jsonutils::hash_option
+FNF:9
+FNH:3
+BRF:0
+BRH:0
+DA:12,1638
+DA:13,1638
+DA:14,0
+DA:15,0
+DA:16,756
+DA:17,21
+DA:18,42
+DA:19,42
+DA:20,0
+DA:21,0
+DA:23,819
+DA:24,1659
+DA:25,840
+DA:26,840
+DA:27,840
+DA:30,1638
+DA:33,777
+DA:34,777
+DA:35,777
+DA:36,0
+DA:37,777
+DA:39,777
+DA:40,777
+DA:42,21
+DA:43,21
+DA:44,21
+DA:45,21
+DA:46,21
+LF:28
+LH:23
+end_of_record
+SF:sk-store/src/event_list.rs
+FN:51,<sk_store::event_list::TraceEventList>::is_empty
+FN:22,<sk_store::event_list::TraceEventList>::append::{closure#2}
+FN:75,<sk_store::event_list::TraceEventList as core::convert::From<alloc::vec::Vec<sk_store::TraceEvent>>>::from
+FN:63,<sk_store::event_list::TraceEventList as core::ops::index::Index<usize>>::index
+FN:43,<sk_store::event_list::TraceEventList>::back
+FN:81,<sk_store::event_list::TraceEventList as core::iter::traits::collect::FromIterator<sk_store::TraceEvent>>::from_iter::<core::iter::adapters::map::Map<core::slice::iter::Iter<(&str, i64)>, sk_store::tests::trace_store_test::test_collect_events_filtered::test_collect_events_filtered::{closure#0}>>
+FN:75,<sk_store::event_list::TraceEventList as core::convert::From<alloc::vec::Vec<sk_store::TraceEvent>>>::from
+FN:69,<sk_store::event_list::TraceEventList as core::convert::From<alloc::collections::vec_deque::VecDeque<sk_store::TraceEvent>>>::from
+FN:43,<sk_store::event_list::TraceEventList>::back
+FN:22,<sk_store::event_list::TraceEventList>::append::{closure#2}
+FN:22,<sk_store::event_list::TraceEventList>::append::{closure#1}
+FN:81,<sk_store::event_list::TraceEventList as core::iter::traits::collect::FromIterator<sk_store::TraceEvent>>::from_iter::<core::iter::adapters::map::Map<core::slice::iter::Iter<(&str, i64)>, sk_store::tests::trace_store_test::test_collect_events_filtered::test_collect_events_filtered::{closure#0}>>
+FN:51,<sk_store::event_list::TraceEventList>::is_empty
+FN:69,<sk_store::event_list::TraceEventList as core::convert::From<alloc::collections::vec_deque::VecDeque<sk_store::TraceEvent>>>::from
+FN:63,<sk_store::event_list::TraceEventList as core::ops::index::Index<usize>>::index
+FN:16,<sk_store::event_list::TraceEventList>::append
+FN:81,<sk_store::event_list::TraceEventList as core::iter::traits::collect::FromIterator<sk_store::TraceEvent>>::from_iter::<_>
+FN:55,<sk_store::event_list::TraceEventList>::len
+FN:47,<sk_store::event_list::TraceEventList>::front
+FN:69,<sk_store::event_list::TraceEventList as core::convert::From<alloc::collections::vec_deque::VecDeque<sk_store::TraceEvent>>>::from
+FN:16,<sk_store::event_list::TraceEventList>::append
+FN:22,<sk_store::event_list::TraceEventList>::append::{closure#2}
+FN:55,<sk_store::event_list::TraceEventList>::len
+FN:47,<sk_store::event_list::TraceEventList>::front
+FN:22,<sk_store::event_list::TraceEventList>::append::{closure#1}
+FN:22,<sk_store::event_list::TraceEventList>::append::{closure#1}
+FN:47,<sk_store::event_list::TraceEventList>::front
+FN:63,<sk_store::event_list::TraceEventList as core::ops::index::Index<usize>>::index
+FN:43,<sk_store::event_list::TraceEventList>::back
+FN:75,<sk_store::event_list::TraceEventList as core::convert::From<alloc::vec::Vec<sk_store::TraceEvent>>>::from
+FN:16,<sk_store::event_list::TraceEventList>::append
+FN:51,<sk_store::event_list::TraceEventList>::is_empty
+FN:55,<sk_store::event_list::TraceEventList>::len
+FNDA:1,<sk_store::event_list::TraceEventList>::is_empty
+FNDA:0,<sk_store::event_list::TraceEventList>::append::{closure#2}
+FNDA:1,<sk_store::event_list::TraceEventList as core::convert::From<alloc::vec::Vec<sk_store::TraceEvent>>>::from
+FNDA:0,<sk_store::event_list::TraceEventList as core::ops::index::Index<usize>>::index
+FNDA:0,<sk_store::event_list::TraceEventList>::back
+FNDA:0,<sk_store::event_list::TraceEventList as core::iter::traits::collect::FromIterator<sk_store::TraceEvent>>::from_iter::<core::iter::adapters::map::Map<core::slice::iter::Iter<(&str, i64)>, sk_store::tests::trace_store_test::test_collect_events_filtered::test_collect_events_filtered::{closure#0}>>
+FNDA:0,<sk_store::event_list::TraceEventList as core::convert::From<alloc::vec::Vec<sk_store::TraceEvent>>>::from
+FNDA:0,<sk_store::event_list::TraceEventList as core::convert::From<alloc::collections::vec_deque::VecDeque<sk_store::TraceEvent>>>::from
+FNDA:0,<sk_store::event_list::TraceEventList>::back
+FNDA:0,<sk_store::event_list::TraceEventList>::append::{closure#2}
+FNDA:0,<sk_store::event_list::TraceEventList>::append::{closure#1}
+FNDA:1,<sk_store::event_list::TraceEventList as core::iter::traits::collect::FromIterator<sk_store::TraceEvent>>::from_iter::<core::iter::adapters::map::Map<core::slice::iter::Iter<(&str, i64)>, sk_store::tests::trace_store_test::test_collect_events_filtered::test_collect_events_filtered::{closure#0}>>
+FNDA:0,<sk_store::event_list::TraceEventList>::is_empty
+FNDA:0,<sk_store::event_list::TraceEventList as core::convert::From<alloc::collections::vec_deque::VecDeque<sk_store::TraceEvent>>>::from
+FNDA:1,<sk_store::event_list::TraceEventList as core::ops::index::Index<usize>>::index
+FNDA:1,<sk_store::event_list::TraceEventList>::append
+FNDA:0,<sk_store::event_list::TraceEventList as core::iter::traits::collect::FromIterator<sk_store::TraceEvent>>::from_iter::<_>
+FNDA:1,<sk_store::event_list::TraceEventList>::len
+FNDA:0,<sk_store::event_list::TraceEventList>::front
+FNDA:0,<sk_store::event_list::TraceEventList as core::convert::From<alloc::collections::vec_deque::VecDeque<sk_store::TraceEvent>>>::from
+FNDA:0,<sk_store::event_list::TraceEventList>::append
+FNDA:0,<sk_store::event_list::TraceEventList>::append::{closure#2}
+FNDA:1,<sk_store::event_list::TraceEventList>::len
+FNDA:0,<sk_store::event_list::TraceEventList>::front
+FNDA:1,<sk_store::event_list::TraceEventList>::append::{closure#1}
+FNDA:0,<sk_store::event_list::TraceEventList>::append::{closure#1}
+FNDA:1,<sk_store::event_list::TraceEventList>::front
+FNDA:1,<sk_store::event_list::TraceEventList as core::ops::index::Index<usize>>::index
+FNDA:1,<sk_store::event_list::TraceEventList>::back
+FNDA:1,<sk_store::event_list::TraceEventList as core::convert::From<alloc::vec::Vec<sk_store::TraceEvent>>>::from
+FNDA:0,<sk_store::event_list::TraceEventList>::append
+FNDA:1,<sk_store::event_list::TraceEventList>::is_empty
+FNDA:0,<sk_store::event_list::TraceEventList>::len
+FNF:33
+FNH:13
+BRF:0
+BRH:0
+DA:16,47
+DA:17,47
+DA:18,0
+DA:19,0
+DA:20,0
+DA:21,0
+DA:22,26
+DA:23,0
+DA:24,0
+DA:27,47
+DA:28,47
+DA:29,38
+DA:30,29
+DA:31,0
+DA:33,18
+DA:34,18
+DA:35,10
+DA:36,8
+DA:38,18
+DA:41,47
+DA:43,8
+DA:44,8
+DA:45,8
+DA:47,8
+DA:48,8
+DA:49,8
+DA:51,66
+DA:52,66
+DA:53,66
+DA:55,93
+DA:56,93
+DA:57,93
+DA:63,104
+DA:64,104
+DA:65,104
+DA:69,0
+DA:70,0
+DA:71,0
+DA:75,11
+DA:76,11
+DA:77,11
+DA:81,1
+DA:82,1
+DA:83,1
+LF:44
+LH:34
+end_of_record
+SF:sk-driver/src/main.rs
+FN:140,sk_driver::main
+FN:83,sk_driver::run::{closure#0}::{closure#0}::{closure#0}
+FN:48,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:45,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:54,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FN:60,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#6}
+FN:51,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FN:69,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#8}
+FN:45,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:57,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#5}
+FN:57,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#5}
+FN:42,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:140,sk_driver::main::{closure#0}
+FN:60,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#6}
+FN:48,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:66,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#7}
+FN:83,sk_driver::run::{closure#0}::{closure#0}
+FN:54,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FN:66,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#7}
+FN:51,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FN:69,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#8}
+FN:42,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:83,sk_driver::run::{closure#0}
+FNDA:0,sk_driver::main
+FNDA:0,sk_driver::run::{closure#0}::{closure#0}::{closure#0}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#6}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#8}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#5}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#5}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,sk_driver::main::{closure#0}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#6}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#7}
+FNDA:0,sk_driver::run::{closure#0}::{closure#0}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#7}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#8}
+FNDA:0,<sk_driver::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,sk_driver::run::{closure#0}
+FNF:23
+FNH:0
+BRF:0
+BRH:0
+DA:42,0
+DA:45,0
+DA:48,0
+DA:51,0
+DA:54,0
+DA:57,0
+DA:60,0
+DA:66,0
+DA:69,0
+DA:83,0
+DA:140,0
+DA:141,0
+DA:142,0
+DA:143,0
+DA:144,0
+LF:15
+LH:0
+end_of_record
+SF:sk-cli/src/main.rs
+FN:63,skctl::main::{closure#0}
+FN:63,skctl::main
+FN:63,skctl::main
+FN:63,skctl::main::{closure#0}
+FNDA:0,skctl::main::{closure#0}
+FNDA:0,skctl::main
+FNDA:0,skctl::main
+FNDA:0,skctl::main::{closure#0}
+FNF:4
+FNH:0
+BRF:0
+BRH:0
+DA:63,0
+DA:64,0
+DA:65,0
+DA:66,0
+DA:67,0
+DA:68,0
+DA:69,0
+DA:70,0
+DA:71,0
+DA:72,0
+DA:73,0
+DA:74,0
+DA:75,0
+DA:76,0
+DA:77,0
+DA:78,0
+DA:79,0
+DA:80,0
+LF:18
+LH:0
+end_of_record
+SF:sk-ctrl/src/main.rs
+FN:84,sk_ctrl::main
+FN:42,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:45,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FN:48,sk_ctrl::run::{closure#0}
+FN:45,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FN:39,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:48,sk_ctrl::run::{closure#0}::{closure#0}::{closure#0}
+FN:42,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:35,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:35,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:77,sk_ctrl::run::{closure#0}::{closure#0}::{closure#0}::{closure#1}
+FN:59,sk_ctrl::run::{closure#0}::{closure#0}::{closure#0}::{closure#0}
+FN:48,sk_ctrl::run::{closure#0}::{closure#0}
+FN:39,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:84,sk_ctrl::main::{closure#0}
+FNDA:0,sk_ctrl::main
+FNDA:0,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FNDA:0,sk_ctrl::run::{closure#0}
+FNDA:0,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FNDA:0,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,sk_ctrl::run::{closure#0}::{closure#0}::{closure#0}
+FNDA:0,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,sk_ctrl::run::{closure#0}::{closure#0}::{closure#0}::{closure#1}
+FNDA:0,sk_ctrl::run::{closure#0}::{closure#0}::{closure#0}::{closure#0}
+FNDA:0,sk_ctrl::run::{closure#0}::{closure#0}
+FNDA:0,<sk_ctrl::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,sk_ctrl::main::{closure#0}
+FNF:15
+FNH:0
+BRF:0
+BRH:0
+DA:35,0
+DA:39,0
+DA:42,0
+DA:45,0
+DA:48,0
+DA:59,0
+DA:60,0
+DA:61,0
+DA:62,0
+DA:63,0
+DA:64,0
+DA:65,0
+DA:66,0
+DA:67,0
+DA:68,0
+DA:69,0
+DA:70,0
+DA:71,0
+DA:72,0
+DA:77,0
+DA:84,0
+DA:85,0
+DA:86,0
+DA:87,0
+DA:88,0
+LF:25
+LH:0
+end_of_record
+SF:sk-cli/src/xray/event.rs
+FN:13,skctl::xray::event::handle_event
+FN:13,skctl::xray::event::handle_event
+FNDA:0,skctl::xray::event::handle_event
+FNDA:0,skctl::xray::event::handle_event
+FNF:2
+FNH:0
+BRF:0
+BRH:0
+DA:13,0
+DA:14,0
+DA:15,0
+DA:16,0
+DA:18,0
+DA:19,0
+DA:20,0
+DA:21,0
+DA:24,0
+DA:25,0
+DA:28,0
+DA:29,0
+DA:31,0
+DA:32,0
+DA:33,0
+DA:34,0
+LF:16
+LH:0
+end_of_record
+SF:sk-cli/src/xray/view/mod.rs
+FN:181,skctl::xray::view::render_object
+FN:103,skctl::xray::view::render_event_list::{closure#0}
+FN:103,skctl::xray::view::render_event_list::{closure#0}
+FN:200,skctl::xray::view::jump_list_state
+FN:32,skctl::xray::view::view
+FN:108,skctl::xray::view::render_event_list::{closure#1}
+FN:87,skctl::xray::view::render_event_list
+FN:116,skctl::xray::view::render_event_list::{closure#1}::{closure#0}
+FN:116,skctl::xray::view::render_event_list::{closure#1}::{closure#0}
+FN:181,skctl::xray::view::render_object
+FN:200,skctl::xray::view::jump_list_state
+FN:32,skctl::xray::view::view
+FN:87,skctl::xray::view::render_event_list
+FN:108,skctl::xray::view::render_event_list::{closure#1}
+FNDA:0,skctl::xray::view::render_object
+FNDA:0,skctl::xray::view::render_event_list::{closure#0}
+FNDA:1,skctl::xray::view::render_event_list::{closure#0}
+FNDA:1,skctl::xray::view::jump_list_state
+FNDA:1,skctl::xray::view::view
+FNDA:1,skctl::xray::view::render_event_list::{closure#1}
+FNDA:1,skctl::xray::view::render_event_list
+FNDA:0,skctl::xray::view::render_event_list::{closure#1}::{closure#0}
+FNDA:1,skctl::xray::view::render_event_list::{closure#1}::{closure#0}
+FNDA:0,skctl::xray::view::render_object
+FNDA:0,skctl::xray::view::jump_list_state
+FNDA:0,skctl::xray::view::view
+FNDA:0,skctl::xray::view::render_event_list
+FNDA:0,skctl::xray::view::render_event_list::{closure#1}
+FNF:14
+FNH:6
+BRF:0
+BRH:0
+DA:32,15
+DA:33,15
+DA:34,15
+DA:35,15
+DA:36,15
+DA:37,15
+DA:38,15
+DA:39,15
+DA:40,15
+DA:41,15
+DA:42,15
+DA:43,15
+DA:44,0
+DA:45,0
+DA:46,0
+DA:47,0
+DA:48,0
+DA:49,0
+DA:50,0
+DA:51,0
+DA:52,0
+DA:53,0
+DA:54,0
+DA:55,0
+DA:57,0
+DA:58,0
+DA:60,15
+DA:61,15
+DA:62,15
+DA:63,15
+DA:64,15
+DA:65,15
+DA:66,15
+DA:67,15
+DA:68,15
+DA:69,15
+DA:70,15
+DA:71,15
+DA:72,15
+DA:73,15
+DA:74,15
+DA:75,0
+DA:76,0
+DA:77,0
+DA:78,15
+DA:81,15
+DA:82,15
+DA:83,15
+DA:84,15
+DA:85,15
+DA:87,15
+DA:88,15
+DA:89,15
+DA:90,15
+DA:91,15
+DA:92,15
+DA:93,15
+DA:94,15
+DA:95,15
+DA:96,15
+DA:97,15
+DA:98,15
+DA:99,8
+DA:100,7
+DA:103,1820
+DA:104,15
+DA:105,15
+DA:106,15
+DA:107,15
+DA:108,15
+DA:109,8
+DA:110,8
+DA:111,8
+DA:112,8
+DA:113,8
+DA:114,8
+DA:115,8
+DA:116,171
+DA:117,8
+DA:118,8
+DA:120,1
+DA:122,7
+DA:124,15
+DA:129,15
+DA:130,7
+DA:131,0
+DA:132,7
+DA:136,7
+DA:144,8
+DA:145,8
+DA:146,8
+DA:147,8
+DA:148,8
+DA:149,8
+DA:150,8
+DA:151,8
+DA:152,8
+DA:153,8
+DA:154,8
+DA:155,0
+DA:156,8
+DA:157,0
+DA:158,8
+DA:163,15
+DA:164,15
+DA:165,15
+DA:166,15
+DA:167,15
+DA:168,15
+DA:169,15
+DA:170,15
+DA:171,15
+DA:172,15
+DA:173,15
+DA:174,15
+DA:175,15
+DA:176,15
+DA:177,15
+DA:178,15
+DA:179,15
+DA:181,0
+DA:182,0
+DA:183,0
+DA:185,0
+DA:186,0
+DA:188,0
+DA:189,0
+DA:190,0
+DA:191,0
+DA:192,0
+DA:193,0
+DA:194,0
+DA:195,0
+DA:197,0
+DA:198,0
+DA:200,13
+DA:201,13
+DA:202,13
+DA:203,13
+DA:204,13
+DA:206,13
+DA:209,7
+DA:215,6
+DA:216,2
+DA:220,4
+DA:227,13
+DA:228,13
+DA:229,13
+DA:230,13
+DA:231,13
+DA:232,2
+DA:233,11
+DA:234,10
+DA:235,10
+DA:236,10
+DA:237,10
+DA:238,13
+LF:157
+LH:122
+end_of_record
+SF:sk-core/src/k8s/pod_ext.rs
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#1}
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#1}
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#1}
+FN:20,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::spec
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#2}
+FN:20,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::spec
+FN:27,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#2}
+FN:59,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::status
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#0}
+FN:27,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec
+FN:59,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::status
+FN:59,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::status
+FN:27,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec
+FN:20,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::spec
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#0}
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#0}
+FN:12,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#2}
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#1}
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#1}
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#1}
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::spec
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#2}
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::spec
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#2}
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::status
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#0}
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::status
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::status
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::spec
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#0}
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#0}
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::PodExt>::stable_spec::{closure#2}
+FNF:18
+FNH:5
+BRF:0
+BRH:0
+DA:12,0
+DA:20,117
+DA:21,117
+DA:22,7
+DA:23,110
+DA:25,117
+DA:27,21
+DA:28,21
+DA:29,21
+DA:30,21
+DA:31,21
+DA:32,21
+DA:34,21
+DA:35,0
+DA:36,0
+DA:37,0
+DA:38,21
+DA:40,21
+DA:41,0
+DA:42,0
+DA:43,0
+DA:44,0
+DA:45,0
+DA:46,0
+DA:47,0
+DA:48,0
+DA:49,0
+DA:50,0
+DA:51,0
+DA:52,0
+DA:53,0
+DA:56,21
+DA:57,21
+DA:59,82
+DA:60,82
+DA:61,0
+DA:62,82
+DA:64,82
+LF:38
+LH:20
+end_of_record
+SF:sk-cli/src/delete.rs
+FN:6,<skctl::delete::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:6,<skctl::delete::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:9,skctl::delete::cmd
+FN:6,<skctl::delete::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:6,<skctl::delete::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:9,skctl::delete::cmd::{closure#0}
+FN:9,skctl::delete::cmd::{closure#0}
+FN:9,skctl::delete::cmd
+FNDA:0,<skctl::delete::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::delete::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::delete::cmd
+FNDA:0,<skctl::delete::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::delete::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::delete::cmd::{closure#0}
+FNDA:0,skctl::delete::cmd::{closure#0}
+FNDA:0,skctl::delete::cmd
+FNF:8
+FNH:0
+BRF:0
+BRH:0
+DA:6,0
+DA:9,0
+DA:10,0
+DA:11,0
+DA:12,0
+DA:13,0
+DA:14,0
+DA:16,0
+DA:17,0
+LF:9
+LH:0
+end_of_record
+SF:sk-store/src/watchers/mod.rs
+FN:34,<sk_store::watchers::MockEventHandler<_>>::checkpoint
+FN:94,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::handle_event::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::returning_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_once::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::MockEventHandler_EventHandler_13065831140148901594<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::with::<predicates::ord::EqPredicate<alloc::vec::Vec<kube_core::dynamic::DynamicObject>>, predicates::ord::EqPredicate<i64>, predicates::constant::BooleanPredicate>
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Rfunc<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::returning_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::times::<_>
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject>>::expect_initialized
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FN:94,<sk_store::watchers::ObjWatcher<_>>::handle_event::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::with::<_, _, _>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::with::<_, _, _>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::times::<usize>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::times::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::MockEventHandler<_>>::expect_deleted
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const_st::<_>
+FN:94,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::handle_event
+FN:34,<sk_store::watchers::MockEventHandler<_> as core::fmt::Debug>::fmt
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::in_sequence
+FN:34,<sk_store::watchers::MockEventHandler_EventHandler_13065831140148901594<_>>::checkpoint
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::once
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Rfunc<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_once_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const::<_>::{closure#0}
+FN:84,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject>>::expect_initialized
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FN:34,<sk_store::watchers::MockEventHandler_EventHandler_13065831140148901594<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::times::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::with::<_, _, _>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::in_sequence
+FN:94,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::handle_event
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::expect
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const_st::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_once_st::<_>
+FN:94,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::handle_event::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::times::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::with::<_, _, _>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_once_st::<_>
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FN:84,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const_st::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::times::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Rfunc<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const::<_>
+FN:80,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start
+FN:56,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::returning::<_>
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:132,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::new_from_parts
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::returning_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::checkpoint
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::returning::<sk_store::watchers::tests::test_handle_initialize_event::{closure#0}::test_handle_initialize_event::{closure#0}::{closure#1}>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::checkpoint
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::withf::<_>
+FN:34,<sk_store::watchers::MockEventHandler_EventHandler_13065831140148901594<_>>::checkpoint
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_once::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::once
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::times::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::once
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::returning::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::returning_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const_st::<_>
+FN:80,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::with::<predicates::ord::EqPredicate<alloc::vec::Vec<kube_core::dynamic::DynamicObject>>, predicates::ord::EqPredicate<i64>, predicates::constant::BooleanPredicate>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::with::<_, _, _>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const_st::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Rfunc<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::checkpoint
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::times::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const_st::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::MockEventHandler<_> as core::fmt::Debug>::fmt
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FN:80,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_once_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::new
+FN:34,<sk_store::watchers::MockEventHandler<_>>::expect_applied
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const_st::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_once::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::in_sequence
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::expect
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_once::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::once
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::expect
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::with::<predicates::ord::EqPredicate<alloc::vec::Vec<kube_core::dynamic::DynamicObject>>, predicates::ord::EqPredicate<i64>, predicates::constant::BooleanPredicate>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::returning_st::<_>
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::returning::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::with::<_, _, _>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::expect
+FN:34,<sk_store::watchers::MockEventHandler<_>>::checkpoint
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_once::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::withf::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FN:84,<sk_store::watchers::ObjWatcher<_>>::start::{closure#0}::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::once
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:94,<sk_store::watchers::ObjWatcher<_>>::handle_event
+FN:34,<sk_store::watchers::MockEventHandler<_>>::expect_deleted
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FN:56,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::new
+FN:56,<sk_store::watchers::ObjWatcher<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_once_st::<_>
+FN:80,<sk_store::watchers::ObjWatcher<_>>::start::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::with::<_, _, _>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::with::<_, _, _>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<_>>::checkpoint
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::times::<usize>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<_>>::checkpoint
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Rfunc<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::checkpoint
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FN:80,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::never
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::times::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const::<_>
+FN:34,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::returning::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_once_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::returning::<sk_store::watchers::tests::test_handle_initialize_event::{closure#0}::test_handle_initialize_event::{closure#0}::{closure#1}>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::expect
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::is_done
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::with::<predicates::ord::EqPredicate<alloc::vec::Vec<kube_core::dynamic::DynamicObject>>, predicates::ord::EqPredicate<i64>, predicates::constant::BooleanPredicate>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::once
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::times::<usize>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Rfunc<_> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::withf_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::withf::<_>
+FN:80,<sk_store::watchers::ObjWatcher<_>>::start
+FN:132,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::new_from_parts
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::returning_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const_st::<_>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::matches
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const_st::<_>::{closure#0}
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_once::<_>
+FN:34,<sk_store::watchers::MockEventHandler<_>>::expect_applied
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::times::<usize>
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::in_sequence
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::expect
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::call
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::new
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FN:34,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FNDA:0,<sk_store::watchers::MockEventHandler<_>>::checkpoint
+FNDA:1,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::handle_event::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::returning_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:1,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_once::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::MockEventHandler_EventHandler_13065831140148901594<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::with::<predicates::ord::EqPredicate<alloc::vec::Vec<kube_core::dynamic::DynamicObject>>, predicates::ord::EqPredicate<i64>, predicates::constant::BooleanPredicate>
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Rfunc<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::returning_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::times::<_>
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject>>::expect_initialized
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FNDA:0,<sk_store::watchers::ObjWatcher<_>>::handle_event::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::with::<_, _, _>
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::with::<_, _, _>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::times::<usize>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::times::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::MockEventHandler<_>>::expect_deleted
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const_st::<_>
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::handle_event
+FNDA:0,<sk_store::watchers::MockEventHandler<_> as core::fmt::Debug>::fmt
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::in_sequence
+FNDA:0,<sk_store::watchers::MockEventHandler_EventHandler_13065831140148901594<_>>::checkpoint
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::once
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Rfunc<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_once_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FNDA:1,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject>>::expect_initialized
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FNDA:1,<sk_store::watchers::MockEventHandler_EventHandler_13065831140148901594<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::times::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::with::<_, _, _>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::in_sequence
+FNDA:1,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::handle_event
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::expect
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_once_st::<_>
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::handle_event::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::times::<_>
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::with::<_, _, _>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_once_st::<_>
+FNDA:1,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::times::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Rfunc<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const::<_>
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::returning::<_>
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::new_from_parts
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::returning_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::checkpoint
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::returning::<sk_store::watchers::tests::test_handle_initialize_event::{closure#0}::test_handle_initialize_event::{closure#0}::{closure#1}>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::checkpoint
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::MockEventHandler_EventHandler_13065831140148901594<_>>::checkpoint
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_once::<_>
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::once
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::times::<_>
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::once
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::returning::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::returning_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const_st::<_>
+FNDA:1,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::with::<predicates::ord::EqPredicate<alloc::vec::Vec<kube_core::dynamic::DynamicObject>>, predicates::ord::EqPredicate<i64>, predicates::constant::BooleanPredicate>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::with::<_, _, _>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::withf::<_>
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Rfunc<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::checkpoint
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::times::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::MockEventHandler<_> as core::fmt::Debug>::fmt
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FNDA:1,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_once_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::new
+FNDA:0,<sk_store::watchers::MockEventHandler<_>>::expect_applied
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_once::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::in_sequence
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::expect
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_once::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::once
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::expect
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::with::<predicates::ord::EqPredicate<alloc::vec::Vec<kube_core::dynamic::DynamicObject>>, predicates::ord::EqPredicate<i64>, predicates::constant::BooleanPredicate>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::returning_st::<_>
+FNDA:0,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::returning::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::matches
+FNDA:1,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::with::<_, _, _>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<_>>::expect
+FNDA:0,<sk_store::watchers::MockEventHandler<_>>::checkpoint
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::verify_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_once::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::ObjWatcher<_>>::start::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const::<_>
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::once
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::ObjWatcher<_>>::handle_event
+FNDA:0,<sk_store::watchers::MockEventHandler<_>>::expect_deleted
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Rfunc<kube_core::dynamic::DynamicObject>>::call_mut
+FNDA:1,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::new
+FNDA:0,<sk_store::watchers::ObjWatcher<_>>::new
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_once_st::<_>
+FNDA:0,<sk_store::watchers::ObjWatcher<_>>::start::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::with::<_, _, _>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::with::<_, _, _>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<_>>::checkpoint
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const::<_>::{closure#0}
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::times::<usize>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<_>>::checkpoint
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Rfunc<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::checkpoint
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:0,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::start::{closure#0}
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<_>>::never
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_>>::times::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::satisfy_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#1}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const::<_>
+FNDA:1,<sk_store::watchers::MockEventHandler<kube_core::dynamic::DynamicObject>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::returning::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_const_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<_>>::new
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::call::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_once_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::new
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::returning::<sk_store::watchers::tests::test_handle_initialize_event::{closure#0}::test_handle_initialize_event::{closure#0}::{closure#1}>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectations<kube_core::dynamic::DynamicObject>>::expect
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Matcher<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<kube_core::dynamic::DynamicObject>>::is_done
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::with::<predicates::ord::EqPredicate<alloc::vec::Vec<kube_core::dynamic::DynamicObject>>, predicates::ord::EqPredicate<i64>, predicates::constant::BooleanPredicate>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::once
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Common<kube_core::dynamic::DynamicObject>>::times::<usize>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Rfunc<_> as core::default::Default>::default
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::withf_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::withf::<_>
+FNDA:0,<sk_store::watchers::ObjWatcher<_>>::start
+FNDA:1,<sk_store::watchers::ObjWatcher<kube_core::dynamic::DynamicObject>>::new_from_parts
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::returning_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Expectation<_>>::return_const_st::<_>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject>>::matches
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<_>>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::return_once::<_>
+FNDA:0,<sk_store::watchers::MockEventHandler<_>>::expect_applied
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::times::<usize>
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__applied::Common<_>>::in_sequence
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Common<kube_core::dynamic::DynamicObject> as core::ops::drop::Drop>::drop
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectations<_>>::expect
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject> as core::default::Default>::default
+FNDA:1,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Expectation<kube_core::dynamic::DynamicObject>>::call
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Expectation<_>>::new
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__deleted::Matcher<kube_core::dynamic::DynamicObject> as core::fmt::Display>::fmt
+FNDA:0,<sk_store::watchers::__mock_MockEventHandler_EventHandler_13065831140148901594::__initialized::Matcher<kube_core::dynamic::DynamicObject>>::matches::{closure#0}
+FNF:326
+FNH:42
+BRF:0
+BRH:0
+DA:34,9
+DA:56,1
+DA:57,1
+DA:58,1
+DA:59,1
+DA:60,1
+DA:61,1
+DA:62,1
+DA:63,1
+DA:64,1
+DA:65,1
+DA:66,1
+DA:67,1
+DA:68,1
+DA:69,1
+DA:70,1
+DA:71,1
+DA:72,1
+DA:73,1
+DA:74,1
+DA:75,1
+DA:76,1
+DA:77,1
+DA:80,2
+DA:81,34
+DA:82,32
+DA:83,32
+DA:84,32
+DA:86,32
+DA:87,0
+DA:88,0
+DA:89,0
+DA:92,2
+DA:94,37
+DA:95,37
+DA:96,37
+DA:97,37
+DA:98,37
+DA:99,2
+DA:100,6
+DA:101,3
+DA:102,23
+DA:104,3
+DA:110,3
+DA:111,1
+DA:112,1
+DA:113,1
+DA:114,1
+DA:115,1
+DA:116,2
+DA:117,3
+DA:120,37
+DA:121,37
+LF:53
+LH:50
+end_of_record
+SF:sk-core/src/k8s/util.rs
+FN:80,sk_core::k8s::util::sanitize_obj
+FN:106,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::namespaced_name
+FN:154,sk_core::k8s::util::label_expr_match
+FN:98,sk_core::k8s::util::split_namespaced_name
+FN:106,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FN:61,sk_core::k8s::util::build_global_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:133,sk_core::k8s::util::build_object_meta_helper::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:75,sk_core::k8s::util::format_gvk_name
+FN:37,sk_core::k8s::util::build_deletable
+FN:113,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::matches
+FN:80,sk_core::k8s::util::sanitize_obj
+FN:113,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::matches
+FN:80,sk_core::k8s::util::sanitize_obj
+FN:98,sk_core::k8s::util::split_namespaced_name
+FN:113,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::matches
+FN:106,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FN:61,sk_core::k8s::util::build_global_object_meta::<_>
+FN:106,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FN:61,sk_core::k8s::util::build_global_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:98,sk_core::k8s::util::split_namespaced_name
+FN:68,sk_core::k8s::util::build_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:133,sk_core::k8s::util::build_object_meta_helper::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:68,sk_core::k8s::util::build_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:37,sk_core::k8s::util::build_deletable
+FN:106,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FN:106,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::namespaced_name
+FN:10,sk_core::k8s::util::add_common_metadata::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:106,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::namespaced_name
+FN:106,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FN:10,sk_core::k8s::util::add_common_metadata::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:50,sk_core::k8s::util::build_containment_label_selector
+FN:68,sk_core::k8s::util::build_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:61,sk_core::k8s::util::build_global_object_meta::<_>
+FN:154,sk_core::k8s::util::label_expr_match
+FN:113,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::matches
+FN:37,sk_core::k8s::util::build_deletable
+FN:10,sk_core::k8s::util::add_common_metadata::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:133,sk_core::k8s::util::build_object_meta_helper::<sk_api::v1::simulation_roots::SimulationRoot>
+FN:50,sk_core::k8s::util::build_containment_label_selector
+FN:10,sk_core::k8s::util::add_common_metadata::<sk_api::v1::simulations::Simulation>
+FN:75,sk_core::k8s::util::format_gvk_name
+FN:154,sk_core::k8s::util::label_expr_match
+FN:113,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::matches
+FN:50,sk_core::k8s::util::build_containment_label_selector
+FN:61,sk_core::k8s::util::build_global_object_meta::<sk_api::v1::simulations::Simulation>
+FN:75,sk_core::k8s::util::format_gvk_name
+FN:68,sk_core::k8s::util::build_object_meta::<sk_api::v1::simulations::Simulation>
+FN:133,sk_core::k8s::util::build_object_meta_helper::<sk_api::v1::simulations::Simulation>
+FN:113,<_ as sk_core::k8s::KubeResourceExt>::matches
+FNDA:0,sk_core::k8s::util::sanitize_obj
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::namespaced_name
+FNDA:1,sk_core::k8s::util::label_expr_match
+FNDA:0,sk_core::k8s::util::split_namespaced_name
+FNDA:1,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FNDA:1,sk_core::k8s::util::build_global_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:1,sk_core::k8s::util::build_object_meta_helper::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:1,sk_core::k8s::util::format_gvk_name
+FNDA:0,sk_core::k8s::util::build_deletable
+FNDA:0,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::matches
+FNDA:0,sk_core::k8s::util::sanitize_obj
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::matches
+FNDA:1,sk_core::k8s::util::sanitize_obj
+FNDA:0,sk_core::k8s::util::split_namespaced_name
+FNDA:1,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::matches
+FNDA:1,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FNDA:0,sk_core::k8s::util::build_global_object_meta::<_>
+FNDA:0,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FNDA:1,sk_core::k8s::util::build_global_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:1,sk_core::k8s::util::split_namespaced_name
+FNDA:0,sk_core::k8s::util::build_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:0,sk_core::k8s::util::build_object_meta_helper::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:1,sk_core::k8s::util::build_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:0,sk_core::k8s::util::build_deletable
+FNDA:1,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::namespaced_name
+FNDA:1,sk_core::k8s::util::add_common_metadata::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:1,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::namespaced_name
+FNDA:0,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::namespaced_name
+FNDA:1,sk_core::k8s::util::add_common_metadata::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:0,sk_core::k8s::util::build_containment_label_selector
+FNDA:1,sk_core::k8s::util::build_object_meta::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:0,sk_core::k8s::util::build_global_object_meta::<_>
+FNDA:0,sk_core::k8s::util::label_expr_match
+FNDA:0,<k8s_openapi::v1_27::api::core::v1::pod::Pod as sk_core::k8s::KubeResourceExt>::matches
+FNDA:1,sk_core::k8s::util::build_deletable
+FNDA:0,sk_core::k8s::util::add_common_metadata::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:1,sk_core::k8s::util::build_object_meta_helper::<sk_api::v1::simulation_roots::SimulationRoot>
+FNDA:0,sk_core::k8s::util::build_containment_label_selector
+FNDA:1,sk_core::k8s::util::add_common_metadata::<sk_api::v1::simulations::Simulation>
+FNDA:0,sk_core::k8s::util::format_gvk_name
+FNDA:0,sk_core::k8s::util::label_expr_match
+FNDA:0,<kube_core::dynamic::DynamicObject as sk_core::k8s::KubeResourceExt>::matches
+FNDA:0,sk_core::k8s::util::build_containment_label_selector
+FNDA:1,sk_core::k8s::util::build_global_object_meta::<sk_api::v1::simulations::Simulation>
+FNDA:0,sk_core::k8s::util::format_gvk_name
+FNDA:1,sk_core::k8s::util::build_object_meta::<sk_api::v1::simulations::Simulation>
+FNDA:1,sk_core::k8s::util::build_object_meta_helper::<sk_api::v1::simulations::Simulation>
+FNDA:0,<_ as sk_core::k8s::KubeResourceExt>::matches
+FNF:49
+FNH:24
+BRF:0
+BRH:0
+DA:10,310
+DA:11,310
+DA:12,310
+DA:13,310
+DA:14,310
+DA:15,310
+DA:16,310
+DA:17,310
+DA:18,310
+DA:19,310
+DA:20,310
+DA:21,310
+DA:22,310
+DA:23,310
+DA:24,310
+DA:25,310
+DA:26,310
+DA:27,310
+DA:28,310
+DA:29,310
+DA:30,310
+DA:31,310
+DA:32,310
+DA:33,310
+DA:34,310
+DA:35,310
+DA:37,7
+DA:38,7
+DA:39,7
+DA:40,7
+DA:41,7
+DA:42,7
+DA:43,7
+DA:44,7
+DA:45,7
+DA:46,7
+DA:47,7
+DA:48,7
+DA:50,0
+DA:51,0
+DA:52,0
+DA:53,0
+DA:54,0
+DA:55,0
+DA:56,0
+DA:57,0
+DA:58,0
+DA:59,0
+DA:61,44
+DA:62,44
+DA:63,44
+DA:64,44
+DA:65,44
+DA:66,44
+DA:68,168
+DA:69,168
+DA:70,168
+DA:71,168
+DA:72,168
+DA:73,168
+DA:75,273
+DA:76,273
+DA:77,273
+DA:80,1
+DA:81,1
+DA:82,1
+DA:83,1
+DA:84,1
+DA:85,1
+DA:86,1
+DA:87,1
+DA:88,1
+DA:90,1
+DA:91,1
+DA:92,1
+DA:93,1
+DA:95,1
+DA:96,1
+DA:98,7
+DA:99,7
+DA:100,7
+DA:101,0
+DA:103,7
+DA:106,1303
+DA:107,1303
+DA:108,1303
+DA:109,0
+DA:111,1303
+DA:113,88
+DA:114,88
+DA:115,16
+DA:116,12
+DA:117,4
+DA:118,4
+DA:120,76
+DA:122,80
+DA:123,77
+DA:124,76
+DA:125,75
+DA:126,1
+DA:128,4
+DA:129,5
+DA:130,88
+DA:133,296
+DA:134,296
+DA:135,296
+DA:136,296
+DA:137,296
+DA:138,296
+DA:139,296
+DA:140,296
+DA:141,296
+DA:142,296
+DA:143,296
+DA:144,296
+DA:145,296
+DA:154,12
+DA:155,12
+DA:156,12
+DA:157,12
+DA:158,12
+DA:159,12
+DA:160,12
+DA:161,12
+DA:162,2
+DA:163,1
+DA:164,1
+DA:166,1
+DA:168,9
+DA:169,2
+DA:170,1
+DA:171,1
+DA:173,1
+DA:175,6
+DA:176,1
+DA:177,2
+DA:179,3
+DA:180,1
+DA:181,1
+DA:183,2
+DA:185,0
+DA:187,12
+LF:142
+LH:129
+end_of_record
+SF:sk-store/src/watchers/dyn_obj_watcher.rs
+FN:53,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#0}
+FN:87,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FN:54,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#1}
+FN:77,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FN:77,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FN:87,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FN:37,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream
+FN:77,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FN:95,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new
+FN:40,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}
+FN:67,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FN:53,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#0}
+FN:77,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FN:67,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FN:67,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FN:87,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FN:37,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream
+FN:67,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FN:67,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FN:54,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#1}
+FN:40,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}
+FN:53,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#0}
+FN:54,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#1}
+FN:77,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FN:87,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FN:87,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FN:95,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new
+FN:77,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FN:37,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream
+FN:40,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}
+FN:87,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FN:67,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#1}
+FNDA:1,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FNDA:1,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FNDA:1,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FNDA:1,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FNDA:1,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#1}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}::{closure#1}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FNDA:1,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new
+FNDA:1,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::deleted
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler>::new_with_stream::{closure#0}
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::initialized
+FNDA:0,<sk_store::watchers::dyn_obj_watcher::DynObjHandler as sk_store::watchers::EventHandler<kube_core::dynamic::DynamicObject>>::applied
+FNF:32
+FNH:7
+BRF:0
+BRH:0
+DA:37,0
+DA:38,0
+DA:39,0
+DA:40,0
+DA:41,0
+DA:42,0
+DA:43,0
+DA:44,0
+DA:47,0
+DA:49,0
+DA:50,0
+DA:51,0
+DA:52,0
+DA:53,0
+DA:54,0
+DA:55,0
+DA:56,0
+DA:57,0
+DA:67,2
+DA:68,2
+DA:69,2
+DA:70,2
+DA:77,6
+DA:78,6
+DA:79,6
+DA:80,6
+DA:87,2
+DA:88,2
+DA:89,2
+DA:90,2
+LF:30
+LH:12
+end_of_record
+SF:sk-cli/src/validation/mod.rs
+FN:63,<skctl::validation::ExplainArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:63,<skctl::validation::ExplainArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:86,skctl::validation::cmd::{closure#0}
+FN:46,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:86,skctl::validation::cmd
+FN:49,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:46,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:86,skctl::validation::cmd
+FN:49,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:83,<skctl::validation::PrintArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:49,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:83,<skctl::validation::PrintArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:46,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:83,<skctl::validation::PrintArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:86,skctl::validation::cmd::{closure#0}
+FN:63,<skctl::validation::ExplainArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:46,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:83,<skctl::validation::PrintArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:49,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:63,<skctl::validation::ExplainArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::validation::ExplainArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::validation::ExplainArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::validation::cmd::{closure#0}
+FNDA:0,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::validation::cmd
+FNDA:0,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::validation::cmd
+FNDA:0,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::validation::PrintArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::validation::PrintArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::validation::PrintArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,skctl::validation::cmd::{closure#0}
+FNDA:0,<skctl::validation::ExplainArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::validation::PrintArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::validation::CheckArgs as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::validation::ExplainArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNF:20
+FNH:0
+BRF:0
+BRH:0
+DA:46,0
+DA:49,0
+DA:63,0
+DA:83,0
+DA:86,0
+DA:87,0
+DA:88,0
+DA:89,0
+DA:90,0
+DA:91,0
+DA:92,0
+DA:93,0
+DA:94,0
+DA:95,0
+DA:96,0
+DA:98,0
+DA:99,0
+DA:101,0
+DA:102,0
+LF:19
+LH:0
+end_of_record
+SF:sk-cli/src/export.rs
+FN:44,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:51,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FN:25,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:44,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:51,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FN:59,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FN:35,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:62,skctl::export::cmd::{closure#0}
+FN:44,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:25,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:35,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:35,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:51,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FN:62,skctl::export::cmd
+FN:62,skctl::export::cmd::{closure#0}
+FN:59,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FN:25,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:59,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FN:44,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:59,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FN:35,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:51,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FN:62,skctl::export::cmd
+FN:25,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#3}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,skctl::export::cmd::{closure#0}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FNDA:0,skctl::export::cmd
+FNDA:0,skctl::export::cmd::{closure#0}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#4}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#4}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#3}
+FNDA:0,skctl::export::cmd
+FNDA:0,<skctl::export::Args as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNF:24
+FNH:0
+BRF:0
+BRH:0
+DA:25,0
+DA:35,0
+DA:44,0
+DA:51,0
+DA:59,0
+DA:62,0
+DA:63,0
+DA:64,0
+DA:65,0
+DA:66,0
+DA:67,0
+DA:68,0
+DA:69,0
+DA:70,0
+DA:71,0
+DA:72,0
+DA:73,0
+DA:74,0
+DA:79,0
+DA:80,0
+DA:81,0
+DA:82,0
+DA:83,0
+DA:84,0
+DA:86,0
+DA:88,0
+DA:89,0
+LF:27
+LH:0
+end_of_record
+SF:sk-store/src/pod_owners_map.rs
+FN:187,<sk_store::pod_owners_map::PodOwnersMap>::pod_owner_meta
+FN:170,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}
+FN:136,<sk_store::pod_owners_map::PodOwnersMap>::filter
+FN:171,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}::{closure#0}
+FN:71,<sk_store::pod_owners_map::PodOwnersMap>::lifecycle_data_for
+FN:163,sk_store::pod_owners_map::filter_lifecycles_map
+FN:106,<sk_store::pod_owners_map::PodOwnersMap>::update_pod_lifecycle
+FN:60,<sk_store::pod_owners_map::PodOwnersMap>::new_from_parts
+FN:60,<sk_store::pod_owners_map::PodOwnersMap>::new_from_parts
+FN:171,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}::{closure#0}
+FN:136,<sk_store::pod_owners_map::PodOwnersMap>::filter
+FN:80,<sk_store::pod_owners_map::PodOwnersMap>::store_new_pod_lifecycle
+FN:170,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}
+FN:80,<sk_store::pod_owners_map::PodOwnersMap>::store_new_pod_lifecycle
+FN:136,<sk_store::pod_owners_map::PodOwnersMap>::filter
+FN:170,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}
+FN:67,<sk_store::pod_owners_map::PodOwnersMap>::has_pod
+FN:187,<sk_store::pod_owners_map::PodOwnersMap>::pod_owner_meta
+FN:106,<sk_store::pod_owners_map::PodOwnersMap>::update_pod_lifecycle
+FN:163,sk_store::pod_owners_map::filter_lifecycles_map
+FN:171,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}::{closure#0}
+FN:106,<sk_store::pod_owners_map::PodOwnersMap>::update_pod_lifecycle
+FN:148,<sk_store::pod_owners_map::PodOwnersMap>::filter::{closure#0}
+FN:163,sk_store::pod_owners_map::filter_lifecycles_map
+FN:67,<sk_store::pod_owners_map::PodOwnersMap>::has_pod
+FN:80,<sk_store::pod_owners_map::PodOwnersMap>::store_new_pod_lifecycle
+FN:71,<sk_store::pod_owners_map::PodOwnersMap>::lifecycle_data_for
+FN:148,<sk_store::pod_owners_map::PodOwnersMap>::filter::{closure#0}
+FN:60,<sk_store::pod_owners_map::PodOwnersMap>::new_from_parts
+FN:67,<sk_store::pod_owners_map::PodOwnersMap>::has_pod
+FN:71,<sk_store::pod_owners_map::PodOwnersMap>::lifecycle_data_for
+FN:148,<sk_store::pod_owners_map::PodOwnersMap>::filter::{closure#0}
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::pod_owner_meta
+FNDA:0,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::filter
+FNDA:0,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}::{closure#0}
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::lifecycle_data_for
+FNDA:0,sk_store::pod_owners_map::filter_lifecycles_map
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::update_pod_lifecycle
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::new_from_parts
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::new_from_parts
+FNDA:0,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}::{closure#0}
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::filter
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::store_new_pod_lifecycle
+FNDA:0,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::store_new_pod_lifecycle
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::filter
+FNDA:1,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::has_pod
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::pod_owner_meta
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::update_pod_lifecycle
+FNDA:1,sk_store::pod_owners_map::filter_lifecycles_map
+FNDA:1,sk_store::pod_owners_map::filter_lifecycles_map::{closure#0}::{closure#0}
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::update_pod_lifecycle
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::filter::{closure#0}
+FNDA:0,sk_store::pod_owners_map::filter_lifecycles_map
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::has_pod
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::store_new_pod_lifecycle
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::lifecycle_data_for
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::filter::{closure#0}
+FNDA:0,<sk_store::pod_owners_map::PodOwnersMap>::new_from_parts
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::has_pod
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::lifecycle_data_for
+FNDA:1,<sk_store::pod_owners_map::PodOwnersMap>::filter::{closure#0}
+FNF:32
+FNH:13
+BRF:0
+BRH:0
+DA:60,15
+DA:61,15
+DA:62,15
+DA:63,15
+DA:64,15
+DA:65,15
+DA:67,7
+DA:68,7
+DA:69,7
+DA:71,12
+DA:72,12
+DA:73,12
+DA:74,12
+DA:75,12
+DA:76,12
+DA:77,12
+DA:78,12
+DA:80,6
+DA:81,6
+DA:82,6
+DA:83,6
+DA:84,6
+DA:85,6
+DA:86,6
+DA:87,6
+DA:88,6
+DA:89,6
+DA:90,3
+DA:91,3
+DA:92,3
+DA:94,3
+DA:95,3
+DA:96,3
+DA:97,3
+DA:101,6
+DA:102,6
+DA:103,6
+DA:104,6
+DA:106,2
+DA:107,2
+DA:108,0
+DA:109,2
+DA:110,2
+DA:111,2
+DA:112,2
+DA:113,2
+DA:114,2
+DA:115,2
+DA:116,2
+DA:117,2
+DA:118,2
+DA:119,2
+DA:120,2
+DA:121,2
+DA:122,2
+DA:123,2
+DA:124,2
+DA:126,2
+DA:127,2
+DA:128,2
+DA:129,2
+DA:132,2
+DA:136,11
+DA:137,11
+DA:138,11
+DA:139,11
+DA:140,11
+DA:141,11
+DA:142,11
+DA:143,11
+DA:144,11
+DA:145,11
+DA:146,11
+DA:147,11
+DA:148,11
+DA:149,3
+DA:150,1
+DA:151,2
+DA:152,2
+DA:153,2
+DA:154,2
+DA:155,2
+DA:156,2
+DA:158,11
+DA:159,11
+DA:160,11
+DA:163,4
+DA:164,4
+DA:165,4
+DA:166,4
+DA:167,4
+DA:168,4
+DA:169,4
+DA:170,4
+DA:171,12
+DA:172,4
+DA:173,2
+DA:174,2
+DA:175,2
+DA:176,4
+DA:177,4
+DA:178,4
+DA:179,4
+DA:180,2
+DA:181,2
+DA:182,2
+DA:183,4
+LF:107
+LH:106
+end_of_record
+SF:sk-core/src/external_storage.rs
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::ops::drop::Drop>::drop
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::once
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FN:128,sk_core::external_storage::test::test_new_sk_object_store::test_new_sk_object_store
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::verify_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::expect
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::times::<usize>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::expect
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::verify_sequence
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc>::call_mut
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as core::default::Default>::default
+FN:87,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc>::call_mut
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::expect
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::fmt::Display>::fmt
+FN:123,sk_core::external_storage::test::test_new_sk_object_store_invalid
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::satisfy_sequence
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning::<sk_tracer::tests::tracer_test::test_export_helper_cloud::{closure#0}::test_export_helper_cloud::{closure#0}::{closure#0}>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as core::fmt::Debug>::fmt
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches
+FN:91,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::satisfy_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::with::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::with::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::is_done
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::satisfy_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::ops::drop::Drop>::drop
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::with::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::checkpoint
+FN:87,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::ops::drop::Drop>::drop
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>
+FN:102,sk_core::external_storage::parse_path
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::once
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::expect
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::verify_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc>::call_mut
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::never
+FN:97,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::fmt::Display>::fmt
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::once
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::once
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::in_sequence
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning::<_>
+FN:97,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::fmt::Display>::fmt
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::ops::drop::Drop>::drop
+FN:91,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::once
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::ops::drop::Drop>::drop
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::is_done
+FN:128,sk_core::external_storage::test::test_new_sk_object_store
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::fmt::Display>::fmt
+FN:91,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::times::<usize>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>
+FN:134,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_1_with_base
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::in_sequence
+FN:97,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::fmt::Display>::fmt
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc>::call_mut
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::times::<usize>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::new
+FN:123,sk_core::external_storage::test::test_new_sk_object_store_invalid
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::satisfy_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::times::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::with::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc>::call_mut
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>::{closure#0}
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_scheme
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::expect
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::times::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_get
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc>::call_mut
+FN:59,<sk_core::external_storage::SkObjectStore>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::times::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_put
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>
+FN:59,<sk_core::external_storage::SkObjectStore>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::times::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_scheme
+FN:134,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_2_without_base
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::ops::drop::Drop>::drop
+FN:134,sk_core::external_storage::test::test_new_sk_object_store_local_path
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::times::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations as core::default::Default>::default
+FN:102,sk_core::external_storage::parse_path
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once_st::<_>
+FN:128,sk_core::external_storage::test::test_new_sk_object_store
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::expect
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::new
+FN:128,sk_core::external_storage::test::test_new_sk_object_store::test_new_sk_object_store
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::ops::drop::Drop>::drop
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations as core::default::Default>::default
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::checkpoint
+FN:91,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::expect
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::new
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as core::fmt::Debug>::fmt
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::ops::drop::Drop>::drop
+FN:106,sk_core::external_storage::parse_path::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::verify_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>
+FN:106,sk_core::external_storage::parse_path::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::is_done
+FN:97,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_put
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::satisfy_sequence
+FN:59,<sk_core::external_storage::SkObjectStore>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::satisfy_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>::{closure#0}
+FN:123,sk_core::external_storage::test::test_new_sk_object_store_invalid::test_new_sk_object_store_invalid
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::with::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::fmt::Display>::fmt
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call
+FN:87,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::with::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc>::call_mut
+FN:134,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_1_with_base
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc>::call_mut
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::new
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::times::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::fmt::Display>::fmt
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::times::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::ops::drop::Drop>::drop
+FN:91,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>::{closure#0}
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::verify_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::once
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::verify_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::times::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::new
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc>::call_mut
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::satisfy_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::verify_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::expect
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::once
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::verify_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::times::<usize>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::expect
+FN:134,sk_core::external_storage::test::test_new_sk_object_store_local_path
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::times::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::satisfy_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::verify_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::is_done
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::once
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::times::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::times::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::never
+FN:91,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::fmt::Display>::fmt
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_get
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::call
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::times::<usize>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::default::Default>::default
+FN:123,sk_core::external_storage::test::test_new_sk_object_store_invalid::test_new_sk_object_store_invalid
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::call
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_put
+FN:97,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::default::Default>::default
+FN:134,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_3_relative
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::is_done
+FN:134,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_2_without_base
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::once
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::never
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::times::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::fmt::Display>::fmt
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::new
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::in_sequence
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_scheme
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning::<sk_tracer::tests::tracer_test::test_export_helper_cloud::{closure#0}::test_export_helper_cloud::{closure#0}::{closure#1}>
+FN:102,sk_core::external_storage::parse_path
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::checkpoint
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::satisfy_sequence
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper>::expect_get
+FN:106,sk_core::external_storage::parse_path::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once_st::<_>
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::matches
+FN:97,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::with
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::in_sequence
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning_st::<_>
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations as core::default::Default>::default
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::new
+FN:43,<sk_core::external_storage::MockObjectStoreWrapper as core::fmt::Debug>::fmt
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::matches
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#1}
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning_st::<_>
+FN:134,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_3_relative
+FN:43,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::times::<usize>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::once
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FNDA:1,sk_core::external_storage::test::test_new_sk_object_store::test_new_sk_object_store
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::verify_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::expect
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::times::<usize>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::expect
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::verify_sequence
+FNDA:1,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches::{closure#0}
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc>::call_mut
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as core::default::Default>::default
+FNDA:1,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::never
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc>::call_mut
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::expect
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#1}
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::fmt::Display>::fmt
+FNDA:1,sk_core::external_storage::test::test_new_sk_object_store_invalid
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning::<sk_tracer::tests::tracer_test::test_export_helper_cloud::{closure#0}::test_export_helper_cloud::{closure#0}::{closure#0}>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as core::fmt::Debug>::fmt
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#0}
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf_st::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#1}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::checkpoint
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::with::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::with::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::is_done
+FNDA:1,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::with::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::checkpoint
+FNDA:1,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::new
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>
+FNDA:0,sk_core::external_storage::parse_path
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::once
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#1}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::expect
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::checkpoint
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::verify_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::matches
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc>::call_mut
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::never
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::once
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::once
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::in_sequence
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning::<_>
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#1}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::once
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::is_done
+FNDA:0,sk_core::external_storage::test::test_new_sk_object_store
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#0}
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::matches
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#1}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::in_sequence
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::times::<usize>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>
+FNDA:1,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_1_with_base
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::in_sequence
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc>::call_mut
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::times::<usize>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::new
+FNDA:0,sk_core::external_storage::test::test_new_sk_object_store_invalid
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::times::<_>
+FNDA:1,<sk_core::external_storage::MockObjectStoreWrapper as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::with::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::is_done
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc>::call_mut
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::expect_scheme
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::expect
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::times::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::expect_get
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Rfunc>::call_mut
+FNDA:1,<sk_core::external_storage::SkObjectStore>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::times::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::expect_put
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>
+FNDA:1,<sk_core::external_storage::SkObjectStore>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::times::<_>
+FNDA:1,<sk_core::external_storage::MockObjectStoreWrapper>::expect_scheme
+FNDA:1,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_2_without_base
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::ops::drop::Drop>::drop
+FNDA:0,sk_core::external_storage::test::test_new_sk_object_store_local_path
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::times::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations as core::default::Default>::default
+FNDA:1,sk_core::external_storage::parse_path
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once_st::<_>
+FNDA:1,sk_core::external_storage::test::test_new_sk_object_store
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::expect
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::new
+FNDA:0,sk_core::external_storage::test::test_new_sk_object_store::test_new_sk_object_store
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::ops::drop::Drop>::drop
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::checkpoint
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::in_sequence
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::expect
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::new
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as core::fmt::Debug>::fmt
+FNDA:1,<sk_core::external_storage::MockObjectStoreWrapper>::new
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::ops::drop::Drop>::drop
+FNDA:0,sk_core::external_storage::parse_path::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning::<_>
+FNDA:1,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::verify_sequence
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>
+FNDA:0,sk_core::external_storage::parse_path::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::is_done
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get
+FNDA:1,<sk_core::external_storage::MockObjectStoreWrapper>::expect_put
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::SkObjectStore>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::in_sequence
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:1,sk_core::external_storage::test::test_new_sk_object_store_invalid::test_new_sk_object_store_invalid
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::with::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::with::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#1}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc>::call_mut
+FNDA:0,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_1_with_base
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc>::call_mut
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#1}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches::{closure#0}
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::new
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::times::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::times::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::ops::drop::Drop>::drop
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:1,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::scheme
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::verify_sequence
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::once
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::verify_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::times::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::with
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::new
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Rfunc>::call_mut
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::withf::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::verify_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::expect
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher>::matches::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::once
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::verify_sequence
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::times::<usize>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Rfunc as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::expect
+FNDA:1,sk_core::external_storage::test::test_new_sk_object_store_local_path
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::times::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::verify_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::is_done
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_const::<_>::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::once
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::times::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::withf_st::<_>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::times::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::never
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::put
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher>::matches
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::expect_get
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::call
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::times::<usize>
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common as core::default::Default>::default
+FNDA:0,sk_core::external_storage::test::test_new_sk_object_store_invalid::test_new_sk_object_store_invalid
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation as core::default::Default>::default
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::call
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper_ObjectStoreWrapper>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::return_once::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::expect_put
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Matcher as core::default::Default>::default
+FNDA:0,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_3_relative
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::withf_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::is_done
+FNDA:0,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_2_without_base
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::once
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::never
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_const_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::times::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Matcher as core::fmt::Display>::fmt
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Matcher>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_once::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::return_const::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::new
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations>::call::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::in_sequence
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::expect_scheme
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::returning::<sk_tracer::tests::tracer_test::test_export_helper_cloud::{closure#0}::test_export_helper_cloud::{closure#0}::{closure#1}>
+FNDA:1,sk_core::external_storage::parse_path
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::checkpoint
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Common>::satisfy_sequence
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper>::expect_get
+FNDA:0,sk_core::external_storage::parse_path::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectations>::call::{closure#1}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::return_once_st::<_>
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as sk_core::external_storage::ObjectStoreWrapper>::put
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::matches
+FNDA:0,<sk_core::external_storage::SkObjectStore as sk_core::external_storage::ObjectStoreWrapper>::get::{closure#0}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::with
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Expectation>::in_sequence
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Common>::withf::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::returning_st::<_>
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectations as core::default::Default>::default
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectation>::new
+FNDA:0,<sk_core::external_storage::MockObjectStoreWrapper as core::fmt::Debug>::fmt
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::matches
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__put::Expectations>::call::{closure#1}
+FNDA:0,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__get::Expectation>::returning_st::<_>
+FNDA:1,sk_core::external_storage::test::test_new_sk_object_store_local_path::case_3_relative
+FNDA:1,<sk_core::external_storage::__mock_MockObjectStoreWrapper_ObjectStoreWrapper::__scheme::Common>::times::<usize>
+FNF:498
+FNH:73
+BRF:0
+BRH:0
+DA:43,119
+DA:59,12
+DA:60,12
+DA:61,11
+DA:62,3
+DA:63,7
+DA:65,1
+DA:68,0
+DA:69,0
+DA:70,0
+DA:73,0
+DA:74,0
+DA:75,0
+DA:77,0
+DA:78,0
+DA:81,11
+DA:82,12
+DA:87,11
+DA:88,11
+DA:89,11
+DA:91,0
+DA:92,0
+DA:93,0
+DA:94,0
+DA:95,0
+DA:97,0
+DA:98,0
+DA:99,0
+DA:102,12
+DA:103,12
+DA:105,2
+DA:106,2
+DA:108,10
+DA:111,12
+DA:112,12
+LF:35
+LH:19
+end_of_record
+SF:sk-tracer/src/main.rs
+FN:89,sk_tracer::run::{closure#0}
+FN:70,<sk_tracer::export>::into_info
+FN:52,sk_tracer::export_helper::{closure#0}
+FN:74,sk_tracer::export::{closure#0}
+FN:70,<sk_tracer::export>::into_info::monomorphized_function
+FN:39,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FN:71,sk_tracer::export
+FN:70,<sk_tracer::export>::into_route
+FN:48,sk_tracer::export_helper
+FN:89,sk_tracer::run::{closure#0}::{closure#0}
+FN:39,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FN:86,sk_tracer::export::{closure#0}::{closure#0}
+FN:45,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FN:42,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FN:70,<sk_tracer::export>::into_info::monomorphized_function::{closure#0}
+FN:124,sk_tracer::main
+FN:45,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FN:89,sk_tracer::run::{closure#0}::{closure#0}::{closure#0}
+FN:117,sk_tracer::run::{closure#0}::{closure#0}::{closure#0}::{closure#2}
+FN:124,sk_tracer::main::{closure#0}
+FN:42,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FN:117,sk_tracer::run::{closure#0}::{closure#0}::{closure#0}::{closure#1}
+FNDA:0,sk_tracer::run::{closure#0}
+FNDA:0,<sk_tracer::export>::into_info
+FNDA:1,sk_tracer::export_helper::{closure#0}
+FNDA:0,sk_tracer::export::{closure#0}
+FNDA:0,<sk_tracer::export>::into_info::monomorphized_function
+FNDA:0,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#0}
+FNDA:0,sk_tracer::export
+FNDA:0,<sk_tracer::export>::into_route
+FNDA:1,sk_tracer::export_helper
+FNDA:0,sk_tracer::run::{closure#0}::{closure#0}
+FNDA:0,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#0}
+FNDA:0,sk_tracer::export::{closure#0}::{closure#0}
+FNDA:0,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#2}
+FNDA:0,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::update_from_arg_matches_mut::{closure#1}
+FNDA:0,<sk_tracer::export>::into_info::monomorphized_function::{closure#0}
+FNDA:0,sk_tracer::main
+FNDA:0,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#2}
+FNDA:0,sk_tracer::run::{closure#0}::{closure#0}::{closure#0}
+FNDA:0,sk_tracer::run::{closure#0}::{closure#0}::{closure#0}::{closure#2}
+FNDA:0,sk_tracer::main::{closure#0}
+FNDA:0,<sk_tracer::Options as clap_builder::derive::FromArgMatches>::from_arg_matches_mut::{closure#1}
+FNDA:0,sk_tracer::run::{closure#0}::{closure#0}::{closure#0}::{closure#1}
+FNF:22
+FNH:2
+BRF:0
+BRH:0
+DA:39,0
+DA:42,0
+DA:45,0
+DA:48,2
+DA:49,2
+DA:50,2
+DA:51,2
+DA:52,2
+DA:53,2
+DA:55,2
+DA:59,1
+DA:60,1
+DA:66,1
+DA:68,2
+DA:70,0
+DA:71,0
+DA:72,0
+DA:73,0
+DA:74,0
+DA:75,0
+DA:77,0
+DA:78,0
+DA:83,0
+DA:84,0
+DA:85,0
+DA:86,0
+DA:87,0
+DA:89,0
+DA:117,0
+DA:124,0
+DA:125,0
+DA:126,0
+DA:127,0
+DA:128,0
+LF:34
+LH:11
+end_of_record

--- a/sk-cli/src/validation/rules/service_account_missing.rs
+++ b/sk-cli/src/validation/rules/service_account_missing.rs
@@ -10,7 +10,10 @@ use std::sync::{
 use json_patch_ext::prelude::*;
 use sk_core::k8s::GVK;
 use sk_core::prelude::*;
-use sk_store::TracerConfig;
+use sk_store::{
+    TraceAction,
+    TracerConfig,
+};
 
 use crate::validation::validator::{
     CheckResult,
@@ -33,42 +36,63 @@ pub struct ServiceAccountMissing {
     pub(crate) seen_service_accounts: HashSet<String>,
 }
 
-impl Diagnostic for ServiceAccountMissing {
-    fn check_next_event(&mut self, event: &mut AnnotatedTraceEvent, config: &TracerConfig) -> CheckResult {
+impl ServiceAccountMissing {
+    fn record_service_accounts(&mut self, event: &mut AnnotatedTraceEvent) {
         for obj in &event.data.applied_objs {
             if let Some(ref type_meta) = obj.types {
-                if &type_meta.kind == "ServiceAccount" {
+                if type_meta.kind == SVC_ACCOUNT_KIND {
                     self.seen_service_accounts.insert(obj.namespaced_name());
                 }
             }
         }
         for obj in &event.data.deleted_objs {
             if let Some(ref type_meta) = obj.types {
-                if &type_meta.kind == "ServiceAccount" {
+                if type_meta.kind == SVC_ACCOUNT_KIND {
                     self.seen_service_accounts.remove(&obj.namespaced_name());
                 }
             }
         }
+    }
+}
+
+impl Diagnostic for ServiceAccountMissing {
+    fn check_next_event(&mut self, event: &mut AnnotatedTraceEvent, config: &TracerConfig) -> CheckResult {
+        // First we check all the objects in this event and record any service accounts we see
+        // (and remove any service accounts that got deleted); this way if the service account
+        // and the pod referencing it are created at the same time we don't fail (maybe we should,
+        // though?  not sure, anyways it's fine for now).
+        self.record_service_accounts(event);
 
         let mut patches = vec![];
         for (i, obj) in event.data.applied_objs.iter().enumerate() {
             let gvk = GVK::from_dynamic_obj(obj)?;
             if let Some(pod_spec_template_path) = config.pod_spec_template_path(&gvk) {
-                let sa_ptrs = [
+                let ptrs = [
                     // serviceAccount is deprecated but still supported (for now)
                     format_ptr!("{pod_spec_template_path}/spec/serviceAccount"),
                     format_ptr!("{pod_spec_template_path}/spec/serviceAccountName"),
                 ];
-                if let Some(sa) = sa_ptrs.iter().filter_map(|ptr| ptr.resolve(&obj.data).ok()).next() {
-                    if !self.seen_service_accounts.contains(sa.as_str().expect("expected string")) {
-                        let fix = AnnotatedTracePatch {
-                            locations: PatchLocations::ObjectReference(
-                                obj.types.clone().unwrap_or_default(),
-                                obj.namespaced_name(),
-                            ),
-                            ops: sa_ptrs.iter().map(|ptr| remove_operation(ptr.clone())).collect(),
-                        };
-                        patches.push((i, vec![fix]));
+
+                // If this obj references a service account that doesn't exist at this point in
+                // time, there are two possible fixes:
+                //
+                // 1) remove the reference to the service account from the pod template spec (recommended, because
+                //    the pod won't exist and can't actually _do_ anything anyways), or
+                // 2) add the service account object in at the beginning of the simulation
+                if let Some(sa) = ptrs.iter().filter_map(|ptr| ptr.resolve(&obj.data).ok()).next() {
+                    // if we're demanding a service account, we must have a namespace and a name,
+                    // these unwraps should be safe
+                    let svc_account = sa.as_str().unwrap();
+                    let svc_account_ns = &obj.namespace().unwrap();
+
+                    if !self.seen_service_accounts.contains(&format!("{svc_account_ns}/{svc_account}")) {
+                        patches.push((
+                            i,
+                            vec![
+                                construct_remove_svc_account_ref_patch(obj, &ptrs),
+                                construct_add_svc_account_patch(svc_account_ns, svc_account),
+                            ],
+                        ));
                     }
                 }
             }
@@ -79,6 +103,29 @@ impl Diagnostic for ServiceAccountMissing {
 
     fn reset(&mut self) {
         self.seen_service_accounts.clear();
+    }
+}
+
+fn construct_remove_svc_account_ref_patch(obj: &DynamicObject, ptrs: &[PointerBuf]) -> AnnotatedTracePatch {
+    AnnotatedTracePatch {
+        locations: PatchLocations::ObjectReference(obj.types.clone().unwrap_or_default(), obj.namespaced_name()),
+        ops: ptrs.iter().map(|ptr| remove_operation(ptr.clone())).collect(),
+    }
+}
+
+fn construct_add_svc_account_patch(svc_account_ns: &str, svc_account: &str) -> AnnotatedTracePatch {
+    AnnotatedTracePatch {
+        locations: PatchLocations::InsertAt(
+            0,
+            TraceAction::ObjectApplied,
+            SVC_ACCOUNT_GVK.into_type_meta(),
+            metav1::ObjectMeta {
+                name: Some(svc_account.into()),
+                namespace: Some(svc_account_ns.into()),
+                ..Default::default()
+            },
+        ),
+        ops: vec![],
     }
 }
 

--- a/sk-cli/src/validation/rules/tests/mod.rs
+++ b/sk-cli/src/validation/rules/tests/mod.rs
@@ -25,7 +25,7 @@ fn test_trace_config() -> TracerConfig {
                     ..Default::default()
                 },
             ),
-            (SA_GVK.clone(), Default::default()),
+            (SVC_ACCOUNT_GVK.clone(), Default::default()),
         ]),
     }
 }

--- a/sk-cli/src/validation/tests/annotated_trace_test.rs
+++ b/sk-cli/src/validation/tests/annotated_trace_test.rs
@@ -1,7 +1,12 @@
 use assertables::*;
 use json_patch_ext::prelude::*;
+use serde_json::json;
+use sk_store::TraceAction;
 
 use super::*;
+use crate::validation::annotated_trace::find_or_create_event_at_ts;
+use crate::validation::AnnotatedTracePatch;
+
 
 #[rstest]
 fn test_apply_patch_everywhere(mut annotated_trace: AnnotatedTrace) {
@@ -40,4 +45,55 @@ fn test_apply_patch_object_reference(mut annotated_trace: AnnotatedTrace) {
             }
         }
     }
+}
+
+#[rstest]
+#[case(TraceAction::ObjectApplied)]
+#[case(TraceAction::ObjectDeleted)]
+fn test_apply_patch_insert_at(mut annotated_trace: AnnotatedTrace, #[case] action: TraceAction) {
+    annotated_trace
+        .apply_patch(AnnotatedTracePatch {
+            locations: PatchLocations::InsertAt(
+                3,
+                action,
+                DS_GVK.into_type_meta(),
+                metav1::ObjectMeta {
+                    namespace: Some(TEST_NAMESPACE.into()),
+                    name: Some(TEST_DAEMONSET.into()),
+                    ..Default::default()
+                },
+            ),
+            ops: vec![add_operation(format_ptr!("/spec"), json!({"minReadySeconds": 5}))],
+        })
+        .unwrap();
+
+    let obj_vec = match action {
+        TraceAction::ObjectApplied => &annotated_trace.events[3].data.applied_objs,
+        TraceAction::ObjectDeleted => &annotated_trace.events[3].data.deleted_objs,
+    };
+
+    assert_eq!(obj_vec[0].metadata.name, Some(TEST_DAEMONSET.into()));
+    assert_eq!(obj_vec[0].metadata.namespace, Some(TEST_NAMESPACE.into()));
+}
+
+#[rstest]
+#[case(0, 0, 4)]
+#[case(1, 1, 4)]
+#[case(3, 3, 5)]
+#[case(7, 4, 5)]
+fn test_find_or_create_event_at_ts(
+    mut annotated_trace: AnnotatedTrace,
+    #[case] ts: i64,
+    #[case] expected_idx: usize,
+    #[case] expected_len: usize,
+) {
+    let event_idx = find_or_create_event_at_ts(&mut annotated_trace.events, ts);
+    assert_eq!(expected_idx, event_idx);
+    assert_len_eq_x!(annotated_trace.events, expected_len);
+}
+
+#[rstest]
+fn test_find_or_create_event_at_ts_empty() {
+    let event_idx = find_or_create_event_at_ts(&mut vec![], 5);
+    assert_eq!(0, event_idx);
 }

--- a/sk-cli/src/validation/tests/mod.rs
+++ b/sk-cli/src/validation/tests/mod.rs
@@ -46,7 +46,7 @@ pub fn annotated_trace() -> AnnotatedTrace {
             deleted_objs: vec![],
         }),
         AnnotatedTraceEvent::new(TraceEvent {
-            ts: 3,
+            ts: 5,
             applied_objs: vec![],
             deleted_objs: vec![test_deployment("test_depl1")],
         }),

--- a/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list@0.snap
+++ b/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list@0.snap
@@ -1,5 +1,5 @@
 ---
-source: sk-cli/src/xray/tests/view_test.rs
+source: sk-cli/src/xray/view/tests/view_test.rs
 expression: cf
 ---
 CompletedFrame {
@@ -10,7 +10,7 @@ CompletedFrame {
             "│>> 00:00:00 (0 applied/0 deleted)                                             │",
             "│   00:00:01 (1 applied/0 deleted)                                             │",
             "│   00:00:02 (3 applied/0 deleted)                       1 error/0 warnings    │",
-            "│   00:00:03 (0 applied/1 deleted)                                             │",
+            "│   00:00:05 (0 applied/1 deleted)                                             │",
             "│                                                                              │",
             "│                                                                              │",
             "│                                                                              │",

--- a/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list@3.snap
+++ b/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list@3.snap
@@ -1,5 +1,5 @@
 ---
-source: sk-cli/src/xray/tests/view_test.rs
+source: sk-cli/src/xray/view/tests/view_test.rs
 expression: cf
 ---
 CompletedFrame {
@@ -10,7 +10,7 @@ CompletedFrame {
             "│   00:00:00 (0 applied/0 deleted)                                             │",
             "│   00:00:01 (1 applied/0 deleted)                                             │",
             "│   00:00:02 (3 applied/0 deleted)                       1 error/0 warnings    │",
-            "│>> 00:00:03 (0 applied/1 deleted)                                             │",
+            "│>> 00:00:05 (0 applied/1 deleted)                                             │",
             "│                                                                              │",
             "│                                                                              │",
             "│                                                                              │",

--- a/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list_event_selected@0.snap
+++ b/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list_event_selected@0.snap
@@ -1,5 +1,5 @@
 ---
-source: sk-cli/src/xray/tests/view_test.rs
+source: sk-cli/src/xray/view/tests/view_test.rs
 expression: cf
 ---
 CompletedFrame {
@@ -11,7 +11,7 @@ CompletedFrame {
             "│++                                                                            │",
             "│   00:00:01 (1 applied/0 deleted)                                             │",
             "│   00:00:02 (3 applied/0 deleted)                       1 error/0 warnings    │",
-            "│   00:00:03 (0 applied/1 deleted)                                             │",
+            "│   00:00:05 (0 applied/1 deleted)                                             │",
             "│                                                                              │",
             "│                                                                              │",
             "│                                                                              │",

--- a/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list_event_selected@2.snap
+++ b/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list_event_selected@2.snap
@@ -13,7 +13,7 @@ CompletedFrame {
             "│++   + test-namespace/test_depl1                                              │",
             "│     + test-namespace/test_depl2xxxxxxxxxxxxxxxxxxxxxx...  1 error/0 warnings │",
             "│     + test-namespace/test_depl3xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx... │",
-            "│   00:00:03 (0 applied/1 deleted)                                             │",
+            "│   00:00:05 (0 applied/1 deleted)                                             │",
             "│                                                                              │",
             "│                                                                              │",
             "│                                                                              │",

--- a/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list_event_selected@3.snap
+++ b/sk-cli/src/xray/view/tests/snapshots/skctl__xray__view__tests__view_test__itest_render_event_list_event_selected@3.snap
@@ -1,5 +1,5 @@
 ---
-source: sk-cli/src/xray/tests/view_test.rs
+source: sk-cli/src/xray/view/tests/view_test.rs
 expression: cf
 ---
 CompletedFrame {
@@ -10,7 +10,7 @@ CompletedFrame {
             "│   00:00:00 (0 applied/0 deleted)                                             │",
             "│   00:00:01 (1 applied/0 deleted)                                             │",
             "│   00:00:02 (3 applied/0 deleted)                       1 error/0 warnings    │",
-            "│>> 00:00:03 (0 applied/1 deleted)                                             │",
+            "│>> 00:00:05 (0 applied/1 deleted)                                             │",
             "│++   - test-namespace/test_depl1                                              │",
             "│                                                                              │",
             "│                                                                              │",

--- a/sk-core/Cargo.toml
+++ b/sk-core/Cargo.toml
@@ -9,7 +9,7 @@ readme.workspace = true
 edition.workspace = true
 
 [features]
-testutils = ["dep:http", "dep:httpmock", "dep:lazy_static", "dep:mockall", "dep:rstest"]
+testutils = ["dep:http", "dep:httpmock", "dep:mockall", "dep:rstest"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -19,6 +19,7 @@ bytes = { workspace = true }
 clockabilly = { workspace = true }
 kube = { workspace = true }
 k8s-openapi = { workspace = true }
+lazy_static = { workspace = true }
 object_store = { workspace = true }
 parse_datetime_fork = { workspace = true }
 paste = { workspace = true }
@@ -37,7 +38,6 @@ url = { workspace = true }
 # testutils dependencies
 http = { workspace = true, optional = true }
 httpmock = { workspace = true,  optional = true }
-lazy_static = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 rstest = { workspace = true, optional = true }
 

--- a/sk-core/src/constants.rs
+++ b/sk-core/src/constants.rs
@@ -1,3 +1,7 @@
+use lazy_static::lazy_static;
+
+use crate::k8s::GVK;
+
 // Well-known labels, annotations, and taints
 pub const KUBERNETES_IO_METADATA_NAME_KEY: &str = "kubernetes.io/metadata.name";
 pub const APP_KUBERNETES_IO_NAME_KEY: &str = "app.kubernetes.io/name";
@@ -28,11 +32,17 @@ pub const SK_LEASE_NAME: &str = "sk-lease";
 pub const RETRY_DELAY_SECONDS: u64 = 5;
 pub const ERROR_RETRY_DELAY_SECONDS: u64 = 30;
 
+// Kinds
+pub const SVC_ACCOUNT_KIND: &str = "ServiceAccount";
+
+// Built-in GVKs
+lazy_static! {
+    pub static ref SVC_ACCOUNT_GVK: GVK = GVK::new("", "v1", SVC_ACCOUNT_KIND);
+}
+
 #[cfg(feature = "testutils")]
 mod test_constants {
-    use lazy_static::lazy_static;
-
-    use crate::k8s::GVK;
+    use super::*;
 
     pub const EMPTY_POD_SPEC_HASH: u64 = 17506812802394981455;
     pub const TEST_DEPLOYMENT: &str = "the-deployment";
@@ -49,7 +59,6 @@ mod test_constants {
     lazy_static! {
         pub static ref DEPL_GVK: GVK = GVK::new("apps", "v1", "Deployment");
         pub static ref DS_GVK: GVK = GVK::new("apps", "v1", "DaemonSet");
-        pub static ref SA_GVK: GVK = GVK::new("", "v1", "ServiceAccount");
     }
 }
 

--- a/sk-core/src/k8s/testutils/objs.rs
+++ b/sk-core/src/k8s/testutils/objs.rs
@@ -24,5 +24,5 @@ pub fn test_daemonset(#[default(TEST_DAEMONSET)] name: &str) -> DynamicObject {
 
 #[fixture]
 pub fn test_service_account(#[default(TEST_SERVICE_ACCOUNT)] name: &str) -> DynamicObject {
-    DynamicObject::new(&name, &ApiResource::from_gvk(&SA_GVK)).within(TEST_NAMESPACE)
+    DynamicObject::new(&name, &ApiResource::from_gvk(&SVC_ACCOUNT_GVK)).within(TEST_NAMESPACE)
 }

--- a/sk-store/src/lib.rs
+++ b/sk-store/src/lib.rs
@@ -29,8 +29,8 @@ pub use crate::index::TraceIndex;
 use crate::pod_owners_map::PodLifecyclesMap;
 pub use crate::store::TraceStore;
 
-#[derive(Debug)]
-enum TraceAction {
+#[derive(Clone, Copy, Debug)]
+pub enum TraceAction {
     ObjectApplied,
     ObjectDeleted,
 }


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
- Adds the `InsertAt` patch location for annotations
- Updates the service_account_missing check to use this patch location as a secondary patch alternative

## Testing done
- make test (new tests added for InsertAt)