### PR TITLE
refactor: use get_or_insert_default

### DIFF
--- a/sk-core/src/k8s/util.rs
+++ b/sk-core/src/k8s/util.rs
@@ -11,11 +11,11 @@ pub fn add_common_metadata<K>(sim_name: &str, owner: &K, meta: &mut metav1::Obje
 where
     K: Resource<DynamicType = ()>,
 {
-    let labels = &mut meta.labels.get_or_insert(BTreeMap::new());
+    let labels = &mut meta.labels.get_or_insert_default();
     labels.insert(SIMULATION_LABEL_KEY.into(), sim_name.into());
     labels.insert(APP_KUBERNETES_IO_NAME_KEY.into(), meta.name.clone().unwrap());
 
-    meta.owner_references.get_or_insert(vec![]).push(metav1::OwnerReference {
+    meta.owner_references.get_or_insert_default().push(metav1::OwnerReference {
         api_version: K::api_version(&()).into(),
         kind: K::kind(&()).into(),
         name: owner.name_any(),

--- a/sk-ctrl/src/objects.rs
+++ b/sk-ctrl/src/objects.rs
@@ -62,7 +62,7 @@ pub fn build_prometheus(
         cfg.remote_timeout.get_or_insert("30s".into());
 
         // Every metric we write should have the simkube_meta label on it for easy filtering
-        cfg.write_relabel_configs.get_or_insert(vec![]).push(WriteRelabelConfigs {
+        cfg.write_relabel_configs.get_or_insert_default().push(WriteRelabelConfigs {
             source_labels: Some(vec![METRICS_NAME_LABEL.into()]), // match every metric
             target_label: Some(SIMKUBE_META_LABEL.into()),
             replacement: Some(sim.name_any()),
@@ -126,7 +126,7 @@ pub fn build_mutating_webhook(
     let owner = metaroot;
     let mut metadata = build_global_object_meta(&ctx.webhook_name, &ctx.name, owner);
     if ctx.opts.use_cert_manager {
-        metadata.annotations.get_or_insert(BTreeMap::new()).insert(
+        metadata.annotations.get_or_insert_default().insert(
             "cert-manager.io/inject-ca-from".into(),
             format!("{}/{}", sim.spec.driver.namespace, DRIVER_CERT_NAME),
         );

--- a/testutils/src/pods.rs
+++ b/testutils/src/pods.rs
@@ -59,15 +59,15 @@ fn build_container_state_finished(t1: i64, t2: i64) -> Option<corev1::ContainerS
 }
 
 fn add_container_with_status(pod: &mut corev1::Pod, state: Option<corev1::ContainerState>, init_container: bool) {
-    let spec = pod.spec.get_or_insert(Default::default());
-    let status = pod.status.get_or_insert(Default::default());
+    let spec = pod.spec.get_or_insert_default();
+    let status = pod.status.get_or_insert_default();
     let (name, containers, statuses) = if init_container {
-        let containers = spec.init_containers.get_or_insert(vec![]);
-        let statuses = status.init_container_statuses.get_or_insert(vec![]);
+        let containers = spec.init_containers.get_or_insert_default();
+        let statuses = status.init_container_statuses.get_or_insert_default();
         (format!("{}-{}", INIT_CONTAINER_PREFIX, containers.len()), containers, statuses)
     } else {
         let containers = &mut spec.containers;
-        let statuses = status.container_statuses.get_or_insert(vec![]);
+        let statuses = status.container_statuses.get_or_insert_default();
         (format!("{}-{}", CONTAINER_PREFIX, containers.len()), containers, statuses)
     };
 


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
`get_or_insert_default` is stabilized now, let's use it

## Testing done
- `make test`
