### PR TITLE
fix: error messages don't stacktrace for 'recoverable' tracer errors

### DIFF
--- a/sk-store/src/watchers/pod_watcher.rs
+++ b/sk-store/src/watchers/pod_watcher.rs
@@ -194,7 +194,7 @@ impl EventHandler<corev1::Pod> for PodHandler {
                 self.owned_pods.insert(ns_name.into(), current_lifecycle_data);
             }
             if let Err(err) = self.handle_pod_applied(ns_name, pod, store.clone()).await {
-                skerr!(err, "(watcher restart) applied pod {} lifecycle data could not be stored", ns_name);
+                error!("(watcher restart) applied pod {ns_name} lifecycle data could not be stored:\n\n{err}\n");
             }
         }
 
@@ -205,9 +205,11 @@ impl EventHandler<corev1::Pod> for PodHandler {
                 .handle_pod_deleted(ns_name, None, current_lifecycle_data.clone(), store.clone(), ts)
                 .await
             {
-                skerr!(err, "(watcher restart) deleted pod {} lifecycle data could not be stored", ns_name);
+                error!("(watcher restart) deleted pod {ns_name} lifecycle data could not be stored:\n\n{err}\n");
             }
         }
+
+        // _this_ function can't error, but other impls (e.g., DynObjWatcher) do
         Ok(())
     }
 }


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
If there are pods that show up that are owned by something that `sk-tracer` doesn't have permissions to watch, previously it would stacktrace and make it look like the program had crashed.  This should still be an error, but let's not make it stacktrace since `sk-tracer` can keep going with other events.

## Testing done
- manual testing