### PR TITLE
chore: bump codecov version

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -93,8 +93,7 @@ jobs:
       - name: Test
         run: make test cover
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json
           fail_ci_if_error: true


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Remove codecov token to let dependabot still work (see details in [the readme](https://github.com/codecov/codecov-action?tab=readme-ov-file), v4 and v5 releases).