### PR TITLE
Add Pause/Resume simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,9 +367,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -614,11 +614,13 @@ checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "clockabilly"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4388a860fbabd311ec78f1ad43127b6f6f18c1bcc9b6626f1e742f26951eef"
+checksum = "acc83f2f9650596578ae42a102ca43b4960da539c440e77c3abfb16ad5a6c7af"
 dependencies = [
+ "async-trait",
  "chrono",
+ "tokio",
 ]
 
 [[package]]
@@ -2443,9 +2445,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-tree"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552c11f51b2a0a8bca9f2a6e1ecd013563de0b9138b2c8689daacc94afad048d"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
 dependencies = [
  "smallvec",
 ]
@@ -3547,6 +3549,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clockabilly",
+ "either",
  "httpmock",
  "k8s-openapi",
  "kube",
@@ -3752,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "snafu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3723,6 +3723,7 @@ dependencies = [
  "const_format",
  "derive_setters",
  "dirs",
+ "httpmock",
  "insta",
  "json-patch-ext",
  "k8s-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,7 +3580,6 @@ dependencies = [
  "anyhow",
  "clap",
  "clockabilly",
- "either",
  "futures",
  "httpmock",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bytes = "1.8.0"
 chrono = "0.4.38"
 clap = { version = "4.5.21", features = ["cargo", "derive", "string"] }
 clap_complete = "4.5.38"
-clockabilly = "0.1.1"
+clockabilly = "0.2.2"
 const_format = "0.2.34"
 derive_setters = "0.1.6"
 dirs = "5.0.1"
@@ -56,7 +56,7 @@ serde = "1.0.215"
 serde_json = "1.0.132"
 serde_yaml = "0.9.34"
 thiserror = "1.0.69"
-tokio = { version = "1.44.2", features = ["io-util", "macros", "process", "rt-multi-thread", "signal"] }
+tokio = { version = "1.44.2", features = ["io-util", "macros", "process", "rt-multi-thread", "time"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5.3"
@@ -72,7 +72,7 @@ insta = "1.41.1"
 mockall = "0.13.1"
 rstest = "0.25.0"
 rstest-log = "0.2.0"
-test-log = { version = "0.2.17", default-features = false, features = ["trace", "color"] }
+test-log = { version = "0.2.17", features = ["trace"] }
 tracing-test = "0.2.5"
 
 [workspace.dependencies.kube]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ RUST_BUILD_IMAGE ?= rust:1.83-bullseye
 CARGO=CARGO_HOME=$(BUILD_DIR)/cargo cargo
 COVERAGE_IGNORES+=sk-api/.* testutils/.*
 EXCLUDE_CRATES=sk-testutils
+RUST_LOG=warn,sk_api,sk_core,sk_store,sk_tracer,sk_ctrl,sk_driver,sk_cli,httpmock=debug
 
 ifndef IN_CI
 DOCKER_ARGS=-it --init
@@ -35,9 +36,6 @@ main:
 skctl:
 	cargo build --profile skctl-dev -p=skctl --color=always
 	cp $(BUILD_DIR)/skctl-dev/skctl $(BUILD_DIR)/.
-
-unit: RUST_LOG=httpmock=debug
-itest: RUST_LOG=httpmock=debug
 
 IMAGE_DEPS += copy-config
 

--- a/k8s/kustomize/sim/simkube.io_simulations.yml
+++ b/k8s/kustomize/sim/simkube.io_simulations.yml
@@ -572,6 +572,10 @@ spec:
                 required:
                 - remoteWriteConfigs
                 type: object
+              pausedTime:
+                format: date-time
+                nullable: true
+                type: string
               repetitions:
                 format: int32
                 nullable: true
@@ -608,6 +612,7 @@ spec:
                 - Initializing
                 - Finished
                 - Failed
+                - Paused
                 - Retrying
                 - Running
                 nullable: true

--- a/k8s/kustomize/sim/simkube.io_simulations.yml
+++ b/k8s/kustomize/sim/simkube.io_simulations.yml
@@ -24,6 +24,18 @@ spec:
       jsonPath: .status.endTime
       name: end time
       type: string
+    - description: multiplicative speed factor for the simulations
+      jsonPath: .spec.speed
+      name: speed factor
+      type: number
+    - description: number of completed simulation runs
+      jsonPath: .status.completedRuns
+      name: completed
+      type: integer
+    - description: total number of simulation runs
+      jsonPath: .spec.repetitions
+      name: total
+      type: integer
     - description: simulation state
       jsonPath: .status.state
       name: state
@@ -44,16 +56,12 @@ spec:
                   port:
                     format: int32
                     type: integer
-                  speed:
-                    format: double
-                    type: number
                   tracePath:
                     type: string
                 required:
                 - image
                 - namespace
                 - port
-                - speed
                 - tracePath
                 type: object
               duration:
@@ -568,12 +576,21 @@ spec:
                 format: int32
                 nullable: true
                 type: integer
+              speed:
+                format: double
+                nullable: true
+                type: number
             required:
             - driver
             type: object
           status:
             nullable: true
             properties:
+              completedRuns:
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
               endTime:
                 format: date-time
                 nullable: true

--- a/k8s/raw/simkube.io_simulations.yml
+++ b/k8s/raw/simkube.io_simulations.yml
@@ -572,6 +572,10 @@ spec:
                 required:
                 - remoteWriteConfigs
                 type: object
+              pausedTime:
+                format: date-time
+                nullable: true
+                type: string
               repetitions:
                 format: int32
                 nullable: true
@@ -608,6 +612,7 @@ spec:
                 - Initializing
                 - Finished
                 - Failed
+                - Paused
                 - Retrying
                 - Running
                 nullable: true

--- a/k8s/raw/simkube.io_simulations.yml
+++ b/k8s/raw/simkube.io_simulations.yml
@@ -24,6 +24,18 @@ spec:
       jsonPath: .status.endTime
       name: end time
       type: string
+    - description: multiplicative speed factor for the simulations
+      jsonPath: .spec.speed
+      name: speed factor
+      type: number
+    - description: number of completed simulation runs
+      jsonPath: .status.completedRuns
+      name: completed
+      type: integer
+    - description: total number of simulation runs
+      jsonPath: .spec.repetitions
+      name: total
+      type: integer
     - description: simulation state
       jsonPath: .status.state
       name: state
@@ -44,16 +56,12 @@ spec:
                   port:
                     format: int32
                     type: integer
-                  speed:
-                    format: double
-                    type: number
                   tracePath:
                     type: string
                 required:
                 - image
                 - namespace
                 - port
-                - speed
                 - tracePath
                 type: object
               duration:
@@ -568,12 +576,21 @@ spec:
                 format: int32
                 nullable: true
                 type: integer
+              speed:
+                format: double
+                nullable: true
+                type: number
             required:
             - driver
             type: object
           status:
             nullable: true
             properties:
+              completedRuns:
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
               endTime:
                 format: date-time
                 nullable: true

--- a/sk-api/src/v1/simulations.rs
+++ b/sk-api/src/v1/simulations.rs
@@ -17,6 +17,7 @@ pub enum SimulationState {
     Initializing,
     Finished,
     Failed,
+    Paused,
     Retrying,
     Running,
 }
@@ -83,6 +84,7 @@ pub struct SimulationSpec {
     pub duration: Option<String>,
     pub repetitions: Option<i32>,
     pub speed: Option<f64>,
+    pub paused_time: Option<DateTime<Utc>>,
     pub hooks: Option<SimulationHooksConfig>,
 }
 
@@ -95,4 +97,10 @@ pub struct SimulationStatus {
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
     pub completed_runs: Option<u64>,
+}
+
+impl Simulation {
+    pub fn speed(&self) -> f64 {
+        self.spec.speed.unwrap_or(1.0)
+    }
 }

--- a/sk-api/src/v1/simulations.rs
+++ b/sk-api/src/v1/simulations.rs
@@ -28,7 +28,6 @@ pub struct SimulationDriverConfig {
     pub image: String,
     pub trace_path: String,
     pub port: i32,
-    pub speed: f64,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
@@ -69,6 +68,9 @@ pub struct SimulationHooksConfig {
 #[kube(
     printcolumn = r#"{"name":"start time", "type":"string", "description":"simulation driver start time", "jsonPath":".status.startTime"}"#,
     printcolumn = r#"{"name":"end time", "type":"string", "description":"simulation driver end time", "jsonPath":".status.endTime"}"#,
+    printcolumn = r#"{"name":"speed factor", "type":"number", "description":"multiplicative speed factor for the simulations", "jsonPath":".spec.speed"}"#,
+    printcolumn = r#"{"name":"completed", "type":"integer", "description":"number of completed simulation runs", "jsonPath":".status.completedRuns"}"#,
+    printcolumn = r#"{"name":"total", "type":"integer", "description":"total number of simulation runs", "jsonPath":".spec.repetitions"}"#,
     printcolumn = r#"{"name":"state", "type":"string", "description":"simulation state", "jsonPath":".status.state"}"#
 )]
 #[serde(rename_all = "camelCase")]
@@ -80,6 +82,7 @@ pub struct SimulationSpec {
     pub metrics: Option<SimulationMetricsConfig>,
     pub duration: Option<String>,
     pub repetitions: Option<i32>,
+    pub speed: Option<f64>,
     pub hooks: Option<SimulationHooksConfig>,
 }
 
@@ -87,7 +90,9 @@ pub struct SimulationSpec {
 #[serde(rename_all = "camelCase")]
 pub struct SimulationStatus {
     pub observed_generation: i64,
+
+    pub state: Option<SimulationState>,
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
-    pub state: Option<SimulationState>,
+    pub completed_runs: Option<u64>,
 }

--- a/sk-cli/Cargo.toml
+++ b/sk-cli/Cargo.toml
@@ -35,6 +35,7 @@ sk-store = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+httpmock = { workspace = true }
 insta = { workspace = true }
 rstest = { workspace = true }
 rstest-log = { workspace = true }

--- a/sk-cli/src/delete.rs
+++ b/sk-cli/src/delete.rs
@@ -6,9 +6,8 @@ pub struct Args {
     pub name: String,
 }
 
-pub async fn cmd(args: &Args) -> EmptyResult {
+pub async fn cmd(args: &Args, client: kube::Client) -> EmptyResult {
     println!("deleting simulation {}...", args.name);
-    let client = kube::Client::try_default().await?;
     let sim_api = kube::Api::<Simulation>::all(client.clone());
 
     sim_api.delete(&args.name, &Default::default()).await?;

--- a/sk-cli/src/pauseresume.rs
+++ b/sk-cli/src/pauseresume.rs
@@ -1,0 +1,169 @@
+use anyhow::bail;
+use clockabilly::prelude::*;
+use kube::api::Patch;
+use serde_json::json;
+use sk_api::v1::SimulationSpec;
+use sk_core::prelude::*;
+
+const PAUSED_TIME_KEY: &str = "pausedTime";
+
+#[derive(clap::Args)]
+pub struct Args {
+    #[arg(long_help = "name of the simulation to operate on")]
+    pub name: String,
+}
+
+pub async fn pause_cmd(args: &Args, client: kube::Client) -> EmptyResult {
+    let sim_api = kube::Api::<Simulation>::all(client.clone());
+
+    let maybe_sim = sim_api.get_opt(&args.name).await?;
+    match maybe_sim {
+        None => bail!("simulation not found: {}", args.name),
+        Some(Simulation {
+            spec: SimulationSpec { paused_time: Some(ts), .. }, ..
+        }) => bail!("simulation {} is already paused at {}", &args.name, ts),
+        _ => (),
+    }
+
+    println!("pausing simulation {}...", args.name);
+    let now = UtcClock.now();
+    let pause_patch = json!({
+        "spec": {
+            PAUSED_TIME_KEY: now,
+    }});
+
+    sim_api
+        .patch(&args.name, &Default::default(), &Patch::Merge(pause_patch))
+        .await?;
+
+    Ok(())
+}
+
+pub async fn resume_cmd(args: &Args, client: kube::Client) -> EmptyResult {
+    let sim_api = kube::Api::<Simulation>::all(client.clone());
+
+    let maybe_sim = sim_api.get_opt(&args.name).await?;
+    match maybe_sim {
+        None => bail!("simulation not found: {}", args.name),
+        Some(Simulation { spec: SimulationSpec { paused_time: None, .. }, .. }) => {
+            bail!("simulation {} is not paused", &args.name)
+        },
+        _ => (),
+    }
+
+    println!("resuming simulation {}...", args.name);
+    let resume_patch = json!({
+        "spec": {
+            PAUSED_TIME_KEY: null,
+    }});
+
+    sim_api
+        .patch(&args.name, &Default::default(), &Patch::Merge(resume_patch))
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use assertables::*;
+    use clockabilly::DateTime;
+    use httpmock::prelude::*;
+    use sk_testutils::*;
+
+    use super::*;
+
+    #[rstest(tokio::test)]
+    async fn test_pause_cmd_not_found() {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        fake_apiserver.handle_not_found(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+
+        let err = pause_cmd(&Args { name: TEST_SIM_NAME.into() }, client).await.unwrap_err();
+
+        assert_eq!(format!("simulation not found: {TEST_SIM_NAME}"), format!("{}", err.root_cause()));
+        fake_apiserver.assert();
+    }
+
+    #[rstest(tokio::test)]
+    async fn test_pause_cmd_already_paused(mut test_sim: Simulation) {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        test_sim.spec.paused_time = DateTime::from_timestamp(0, 0);
+        fake_apiserver.handle(move |when, then| {
+            when.path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+            then.json_body_obj(&test_sim);
+        });
+
+        let err = pause_cmd(&Args { name: TEST_SIM_NAME.into() }, client).await.unwrap_err();
+
+        assert_starts_with!(format!("{}", err.root_cause()), format!("simulation {TEST_SIM_NAME} is already paused"));
+        fake_apiserver.assert();
+    }
+
+    #[rstest(tokio::test)]
+    async fn test_pause_cmd_not_paused(test_sim: Simulation) {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        let mut test_sim_patched = test_sim.clone();
+        test_sim_patched.spec.paused_time = DateTime::from_timestamp(0, 0);
+        fake_apiserver.handle(move |when, then| {
+            when.method(GET)
+                .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+            then.json_body_obj(&test_sim);
+        });
+        fake_apiserver.handle(move |when, then| {
+            when.method(PATCH)
+                .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"))
+                .body_matches("\\{\"spec\":\\{\"pausedTime\":\".*\"\\}\\}");
+            then.json_body_obj(&test_sim_patched);
+        });
+
+        pause_cmd(&Args { name: TEST_SIM_NAME.into() }, client).await.unwrap();
+        fake_apiserver.assert();
+    }
+
+
+    #[rstest(tokio::test)]
+    async fn test_resume_cmd_not_found() {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        fake_apiserver.handle_not_found(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+
+        let err = resume_cmd(&Args { name: TEST_SIM_NAME.into() }, client).await.unwrap_err();
+
+        assert_eq!(format!("simulation not found: {TEST_SIM_NAME}"), format!("{}", err.root_cause()));
+        fake_apiserver.assert();
+    }
+
+    #[rstest(tokio::test)]
+    async fn test_resume_cmd_not_paused(test_sim: Simulation) {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        fake_apiserver.handle(move |when, then| {
+            when.path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+            then.json_body_obj(&test_sim);
+        });
+
+        let err = resume_cmd(&Args { name: TEST_SIM_NAME.into() }, client).await.unwrap_err();
+
+        assert_eq!(format!("simulation {TEST_SIM_NAME} is not paused"), format!("{}", err.root_cause()));
+        fake_apiserver.assert();
+    }
+
+    #[rstest(tokio::test)]
+    async fn test_resume_cmd_paused(test_sim: Simulation) {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        let mut test_sim_patched = test_sim.clone();
+        test_sim_patched.spec.paused_time = DateTime::from_timestamp(0, 0);
+        fake_apiserver.handle(move |when, then| {
+            when.method(GET)
+                .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+            then.json_body_obj(&test_sim_patched);
+        });
+        fake_apiserver.handle(move |when, then| {
+            when.method(PATCH)
+                .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"))
+                .body_matches("\\{\"spec\":\\{\"pausedTime\":null\\}\\}");
+            then.json_body_obj(&test_sim);
+        });
+
+        resume_cmd(&Args { name: TEST_SIM_NAME.into() }, client).await.unwrap();
+        fake_apiserver.assert();
+    }
+}

--- a/sk-cli/src/run.rs
+++ b/sk-cli/src/run.rs
@@ -1,4 +1,5 @@
 use clap::crate_version;
+use clockabilly::prelude::*;
 use serde::Serialize;
 use sk_api::prometheus::PrometheusRemoteWrite;
 use sk_api::v1::{
@@ -40,6 +41,9 @@ pub struct Args {
         default_value = "1"
     )]
     pub repetitions: i32,
+
+    #[arg(long, long_help = "start the simulation in the \"paused\" state")]
+    pub start_paused: bool,
 
     #[arg(
         short = 'I',
@@ -179,6 +183,7 @@ pub async fn cmd(args: &Args) -> EmptyResult {
 
     let hooks = merge_hooks(&args.hooks)?;
 
+    let paused_time = if args.start_paused { Some(UtcClock.now()) } else { None };
     let sim = Simulation::new(
         &args.name,
         SimulationSpec {
@@ -192,6 +197,7 @@ pub async fn cmd(args: &Args) -> EmptyResult {
             metrics: metrics_config,
             repetitions: Some(args.repetitions),
             speed: Some(args.speed),
+            paused_time,
             hooks,
         },
     );

--- a/sk-cli/src/run.rs
+++ b/sk-cli/src/run.rs
@@ -164,7 +164,7 @@ pub struct Args {
     pub version: (),
 }
 
-pub async fn cmd(args: &Args) -> EmptyResult {
+pub async fn cmd(args: &Args, client: kube::Client) -> EmptyResult {
     println!("running simulation with configuration:\n\n---\n{}", serde_yaml::to_string(args)?);
 
     let metrics_config = (!args.disable_metrics).then_some(SimulationMetricsConfig {
@@ -201,7 +201,6 @@ pub async fn cmd(args: &Args) -> EmptyResult {
             hooks,
         },
     );
-    let client = kube::Client::try_default().await?;
     let sim_api = kube::Api::<Simulation>::all(client.clone());
 
     sim_api.create(&Default::default(), &sim).await?;

--- a/sk-cli/src/run.rs
+++ b/sk-cli/src/run.rs
@@ -187,11 +187,11 @@ pub async fn cmd(args: &Args) -> EmptyResult {
                 image: args.driver_image.clone(),
                 port: args.driver_port,
                 trace_path: args.trace_path.clone(),
-                speed: args.speed,
             },
             duration: args.duration.clone(),
             metrics: metrics_config,
             repetitions: Some(args.repetitions),
+            speed: Some(args.speed),
             hooks,
         },
     );

--- a/sk-cli/src/snapshot.rs
+++ b/sk-cli/src/snapshot.rs
@@ -42,12 +42,11 @@ pub struct Args {
     pub output: String,
 }
 
-pub async fn cmd(args: &Args) -> EmptyResult {
+pub async fn cmd(args: &Args, client: kube::Client) -> EmptyResult {
     println!("Reading config from {}...", args.config_file);
     let config = TracerConfig::load(&args.config_file)?;
 
     println!("Connecting to kubernetes cluster...");
-    let client = kube::Client::try_default().await?;
     let mut apiset = DynamicApiSet::new(client.clone());
 
     println!("Loading snapshot into store...");

--- a/sk-cli/src/snapshot.rs
+++ b/sk-cli/src/snapshot.rs
@@ -5,10 +5,7 @@ use std::sync::{
     Mutex,
 };
 
-use clockabilly::{
-    Clockable,
-    UtcClock,
-};
+use clockabilly::prelude::*;
 use sk_api::v1::ExportFilters;
 use sk_core::k8s::DynamicApiSet;
 use sk_core::prelude::*;

--- a/sk-core/Cargo.toml
+++ b/sk-core/Cargo.toml
@@ -17,6 +17,7 @@ async-recursion = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 clockabilly = { workspace = true }
+either = { workspace = true }
 kube = { workspace = true }
 k8s-openapi = { workspace = true }
 lazy_static = { workspace = true }

--- a/sk-core/src/k8s/lease.rs
+++ b/sk-core/src/k8s/lease.rs
@@ -1,8 +1,7 @@
+use clockabilly::prelude::*;
 use clockabilly::{
-    Clockable,
     DateTime,
     Utc,
-    UtcClock,
 };
 use k8s_openapi::api::coordination::v1 as coordinationv1;
 use kube::api::Patch;

--- a/sk-core/src/k8s/tests/lease_test.rs
+++ b/sk-core/src/k8s/tests/lease_test.rs
@@ -1,8 +1,6 @@
 use clockabilly::mock::MockUtcClock;
-use clockabilly::{
-    Clockable,
-    DateTime,
-};
+use clockabilly::prelude::*;
+use clockabilly::DateTime;
 // can't import prelude because that doesn't include "PATCH" for some reason
 use httpmock::Method::*;
 use k8s_openapi::api::coordination::v1 as coordinationv1;

--- a/sk-ctrl/Cargo.toml
+++ b/sk-ctrl/Cargo.toml
@@ -12,7 +12,6 @@ edition.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 clockabilly = { workspace = true }
-either = { workspace = true }
 futures = { workspace = true }
 kube = { workspace = true }
 k8s-openapi = { workspace = true }

--- a/sk-ctrl/src/tests/controller_test.rs
+++ b/sk-ctrl/src/tests/controller_test.rs
@@ -4,7 +4,6 @@ use clockabilly::{
     Clockable,
     UtcClock,
 };
-use either::for_both;
 use httpmock::prelude::*;
 use kube::runtime::controller::Action;
 use serde_json::json;
@@ -41,8 +40,10 @@ async fn test_fetch_driver_state_no_driver(test_sim: Simulation, test_sim_root: 
             .path(format!("/apis/coordination.k8s.io/v1/namespaces/{TEST_CTRL_NAMESPACE}/leases/{SK_LEASE_NAME}"));
         then.json_body_obj(&lease_obj);
     });
-    let sim_state =
-        for_both!(fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE).await.unwrap(), s => s.0);
+    let sim_state = fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE)
+        .await
+        .unwrap()
+        .0;
     assert_eq!(SimulationState::Initializing, sim_state);
     fake_apiserver.assert();
 }
@@ -63,8 +64,10 @@ async fn test_fetch_driver_state_driver_no_status(test_sim: Simulation, test_sim
             .path(format!("/apis/coordination.k8s.io/v1/namespaces/{TEST_CTRL_NAMESPACE}/leases/{SK_LEASE_NAME}"));
         then.json_body_obj(&lease_obj);
     });
-    let sim_state =
-        for_both!(fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE).await.unwrap(), s => s.0);
+    let sim_state = fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE)
+        .await
+        .unwrap()
+        .0;
     assert_eq!(SimulationState::Running, sim_state);
     fake_apiserver.assert();
 }
@@ -89,8 +92,10 @@ async fn test_fetch_driver_state_driver_running(test_sim: Simulation, test_sim_r
             .path(format!("/apis/coordination.k8s.io/v1/namespaces/{TEST_CTRL_NAMESPACE}/leases/{SK_LEASE_NAME}"));
         then.json_body_obj(&lease_obj);
     });
-    let sim_state =
-        for_both!(fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE).await.unwrap(), s => s.0);
+    let sim_state = fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE)
+        .await
+        .unwrap()
+        .0;
     assert_eq!(SimulationState::Running, sim_state);
     fake_apiserver.assert();
 }
@@ -123,8 +128,10 @@ async fn test_fetch_driver_state_driver_finished(
             },
         }));
     });
-    let sim_state =
-        for_both!(fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE).await.unwrap(), s => s.0);
+    let sim_state = fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE)
+        .await
+        .unwrap()
+        .0;
     assert_eq!(expected_state, sim_state);
     fake_apiserver.assert();
 }
@@ -145,8 +152,10 @@ async fn test_fetch_driver_state_lease_waiting(test_sim: Simulation, test_sim_ro
         then.json_body_obj(&other_lease_obj);
     });
 
-    let sim_state =
-        for_both!(fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE).await.unwrap(), s => s.0);
+    let sim_state = fetch_driver_state(&ctx, &test_sim, &test_sim_root, TEST_CTRL_NAMESPACE)
+        .await
+        .unwrap()
+        .0;
     assert_eq!(SimulationState::Blocked, sim_state);
     fake_apiserver.assert();
 }

--- a/sk-ctrl/src/tests/controller_test.rs
+++ b/sk-ctrl/src/tests/controller_test.rs
@@ -1,9 +1,6 @@
 use std::env;
 
-use clockabilly::{
-    Clockable,
-    UtcClock,
-};
+use clockabilly::prelude::*;
 use httpmock::prelude::*;
 use kube::runtime::controller::Action;
 use serde_json::json;

--- a/sk-driver/src/tests/helpers.rs
+++ b/sk-driver/src/tests/helpers.rs
@@ -1,19 +1,27 @@
 use std::sync::Arc;
 
-use sk_api::v1::SimulationSpec;
 use sk_store::TraceEvent;
 use tokio::sync::Mutex;
 
 use super::*;
 
-pub fn build_trace_data(has_start_marker: bool) -> Vec<u8> {
+pub const TRACE_START: i64 = 1709241485;
+
+pub fn build_trace_data(has_start_marker: bool, duration: Option<i64>) -> Vec<u8> {
     // I want the trace data to be easily editable, so we load it from a plain-text JSON file and
     // then re-encode it into msgpack so we can pass the data to import
     let mut exported_trace = exported_trace_from_json("trace");
 
     if has_start_marker {
         exported_trace.prepend_event(TraceEvent {
-            ts: 1709241485,
+            ts: TRACE_START,
+            applied_objs: vec![],
+            deleted_objs: vec![],
+        });
+    }
+    if let Some(d) = duration {
+        exported_trace.append_event(TraceEvent {
+            ts: TRACE_START + d,
             applied_objs: vec![],
             deleted_objs: vec![],
         });
@@ -26,11 +34,10 @@ pub fn build_driver_context(
     owners_cache: Arc<Mutex<OwnersCache>>,
     store: Arc<dyn TraceStorable + Send + Sync>,
 ) -> DriverContext {
-    let sim = Simulation::new(TEST_SIM_NAME, SimulationSpec { speed: Some(1.0), ..Default::default() });
     DriverContext {
         name: TEST_DRIVER_NAME.into(),
+        sim_name: TEST_SIM_NAME.into(),
         root_name: TEST_DRIVER_ROOT_NAME.into(),
-        sim,
         ctrl_ns: TEST_CTRL_NAMESPACE.into(),
         virtual_ns_prefix: TEST_VIRT_NS_PREFIX.into(),
         owners_cache,

--- a/sk-driver/src/tests/helpers.rs
+++ b/sk-driver/src/tests/helpers.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use sk_api::v1::{
-    SimulationDriverConfig,
-    SimulationSpec,
-};
+use sk_api::v1::SimulationSpec;
 use sk_store::TraceEvent;
 use tokio::sync::Mutex;
 
@@ -29,13 +26,7 @@ pub fn build_driver_context(
     owners_cache: Arc<Mutex<OwnersCache>>,
     store: Arc<dyn TraceStorable + Send + Sync>,
 ) -> DriverContext {
-    let sim = Simulation::new(
-        TEST_SIM_NAME,
-        SimulationSpec {
-            driver: SimulationDriverConfig { speed: 1.0, ..Default::default() },
-            ..Default::default()
-        },
-    );
+    let sim = Simulation::new(TEST_SIM_NAME, SimulationSpec { speed: Some(1.0), ..Default::default() });
     DriverContext {
         name: TEST_DRIVER_NAME.into(),
         root_name: TEST_DRIVER_ROOT_NAME.into(),

--- a/sk-driver/src/tests/mod.rs
+++ b/sk-driver/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod helpers;
 mod mutation_test;
 mod runner_test;
+mod util_test;
 
 use sk_core::prelude::*;
 use sk_testutils::*;

--- a/sk-driver/src/tests/runner_test.rs
+++ b/sk-driver/src/tests/runner_test.rs
@@ -1,8 +1,6 @@
 use clockabilly::mock::MockUtcClock;
-use clockabilly::{
-    Clockable,
-    UtcClock,
-};
+use clockabilly::prelude::*;
+use clockabilly::DateTime;
 use httpmock::Method::*;
 use serde_json::json;
 use sk_api::v1::SimulationRootSpec;
@@ -11,6 +9,7 @@ use sk_core::k8s::build_lease;
 use super::helpers::{
     build_driver_context,
     build_trace_data,
+    TRACE_START,
 };
 use super::*;
 use crate::runner::{
@@ -18,6 +17,7 @@ use crate::runner::{
     build_virtual_obj,
     cleanup_trace,
 };
+use crate::util::DRIVER_PAUSED_WAIT_SECONDS;
 
 // Must match the namespace in tests/data/trace.json
 const TEST_NS_NAME: &str = "default";
@@ -143,11 +143,11 @@ mod itest {
     #[rstest(tokio::test)]
     #[case::has_start_marker(true)]
     #[case::no_start_marker(false)]
-    async fn test_driver_run(#[case] has_start_marker: bool) {
+    async fn test_driver_run(test_sim: Simulation, #[case] has_start_marker: bool) {
         let (mut fake_apiserver, client) = make_fake_apiserver();
         let cache = Arc::new(Mutex::new(OwnersCache::new(DynamicApiSet::new(client.clone()))));
 
-        let trace_data = build_trace_data(has_start_marker);
+        let trace_data = build_trace_data(has_start_marker, None);
         let store = Arc::new(TraceStore::import(trace_data, &None).unwrap());
         let ctx = build_driver_context(cache, store);
 
@@ -160,8 +160,9 @@ mod itest {
             spec: SimulationRootSpec {},
         };
         let virt_ns = build_virtual_ns(&ctx, &root.clone(), TEST_NS_NAME);
-        let lease_obj = build_lease(&ctx.sim, &root, TEST_CTRL_NAMESPACE, UtcClock.now());
-        let patched_lease_obj = build_lease(&ctx.sim, &root, TEST_CTRL_NAMESPACE, UtcClock.now());
+        let lease_obj = build_lease(&test_sim, &root, TEST_CTRL_NAMESPACE, UtcClock.now());
+        let patched_lease_obj = build_lease(&test_sim, &root, TEST_CTRL_NAMESPACE, UtcClock.now());
+        let test_sim_clone = test_sim.clone();
 
         fake_apiserver.handle(move |when, then| {
             // In theory the driver needs to create the driver root first, but here we return
@@ -195,6 +196,14 @@ mod itest {
             ));
             then.json_body(status_ok());
         });
+        fake_apiserver.handle_multiple(
+            move |when, then| {
+                when.method(GET)
+                    .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+                then.json_body_obj(&test_sim_clone);
+            },
+            if has_start_marker { 2 } else { 1 },
+        );
         fake_apiserver.handle(|when, then| {
             when.method(DELETE).path(format!(
                 "/apis/apps/v1/namespaces/{TEST_VIRT_NS_PREFIX}-{TEST_NS_NAME}/deployments/nginx-deployment-2"
@@ -206,7 +215,180 @@ mod itest {
                 .method(DELETE);
             then.json_body(status_ok());
         });
-        run_trace(ctx, client).await.unwrap();
+        run_trace(ctx, client, test_sim).await.unwrap();
         fake_apiserver.assert();
+    }
+
+    #[rstest(tokio::test)]
+    #[case::not_paused(false, 10)]
+    #[case::paused(true, 20)]
+    async fn test_driver_run_internal_paused(
+        mut test_sim: Simulation,
+        #[case] paused: bool,
+        #[case] expected_end_ts: i64,
+    ) {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        let cache = Arc::new(Mutex::new(OwnersCache::new(DynamicApiSet::new(client.clone()))));
+
+        let trace_data = build_trace_data(false, Some(10));
+        let store = Arc::new(TraceStore::import(trace_data, &None).unwrap());
+        let ctx = build_driver_context(cache, store);
+
+        let root = SimulationRoot {
+            metadata: metav1::ObjectMeta {
+                name: Some(TEST_DRIVER_ROOT_NAME.into()),
+                uid: Some("puwern5t".into()),
+                ..Default::default()
+            },
+            spec: SimulationRootSpec {},
+        };
+        let virt_ns = build_virtual_ns(&ctx, &root.clone(), TEST_NS_NAME);
+
+        let test_sim_clone = test_sim.clone();
+        let mut clock = MockUtcClock::boxed(0);
+        if paused {
+            test_sim.spec.paused_time = Some(clock.now());
+        }
+
+        fake_apiserver.handle_not_found(format!("/api/v1/namespaces/{TEST_VIRT_NS_PREFIX}-{TEST_NS_NAME}"));
+        fake_apiserver.handle(move |when, then| {
+            when.path("/api/v1/namespaces".to_string());
+            then.json_body_obj(&virt_ns);
+        });
+        fake_apiserver.handle(|when, then| {
+            when.path("/apis/apps/v1".to_string());
+            then.json_body(apps_v1_discovery());
+        });
+        fake_apiserver.handle(|when, then| {
+            when.method(PATCH).path(format!(
+                "/apis/apps/v1/namespaces/{TEST_VIRT_NS_PREFIX}-{TEST_NS_NAME}/deployments/nginx-deployment"
+            ));
+            then.json_body(status_ok());
+        });
+        fake_apiserver.handle(|when, then| {
+            when.method(DELETE).path(format!(
+                "/apis/apps/v1/namespaces/{TEST_VIRT_NS_PREFIX}-{TEST_NS_NAME}/deployments/nginx-deployment-2"
+            ));
+            then.json_body(status_ok());
+        });
+        let sim_handle_id = fake_apiserver.handle_multiple(
+            move |when, then| {
+                when.method(GET)
+                    .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+                then.json_body_obj(&test_sim);
+            },
+            2,
+        );
+
+        if paused {
+            let mut fake_apiserver_clone = fake_apiserver.clone();
+            clock.add_callback(DRIVER_PAUSED_WAIT_SECONDS + 1, move || {
+                fake_apiserver_clone.drop(sim_handle_id);
+                let test_sim_clone = test_sim_clone.clone(); // Don't understand why this clone is needed
+                fake_apiserver_clone.handle_multiple(
+                    move |when, then| {
+                        when.method(GET)
+                            .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+                        then.json_body_obj(&test_sim_clone);
+                    },
+                    2,
+                );
+            });
+        }
+
+        run_trace_internal(&ctx, client, 1.0, root, TRACE_START, clock.clone())
+            .await
+            .unwrap();
+        fake_apiserver.assert();
+        assert_eq!(expected_end_ts, clock.now_ts());
+    }
+
+    #[rstest(tokio::test)]
+    async fn test_driver_run_internal_paused_in_middle(test_sim: Simulation) {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        let cache = Arc::new(Mutex::new(OwnersCache::new(DynamicApiSet::new(client.clone()))));
+
+        let trace_data = build_trace_data(false, Some(10));
+        let store = Arc::new(TraceStore::import(trace_data, &None).unwrap());
+        let ctx = build_driver_context(cache, store);
+
+        let root = SimulationRoot {
+            metadata: metav1::ObjectMeta {
+                name: Some(TEST_DRIVER_ROOT_NAME.into()),
+                uid: Some("puwern5t".into()),
+                ..Default::default()
+            },
+            spec: SimulationRootSpec {},
+        };
+        let virt_ns = build_virtual_ns(&ctx, &root.clone(), TEST_NS_NAME);
+
+        let test_sim_clone_1 = test_sim.clone();
+        let test_sim_clone_2 = test_sim.clone();
+        let mut clock = MockUtcClock::boxed(0);
+
+        fake_apiserver.handle_not_found(format!("/api/v1/namespaces/{TEST_VIRT_NS_PREFIX}-{TEST_NS_NAME}"));
+        fake_apiserver.handle(move |when, then| {
+            when.path("/api/v1/namespaces".to_string());
+            then.json_body_obj(&virt_ns);
+        });
+        fake_apiserver.handle(|when, then| {
+            when.path("/apis/apps/v1".to_string());
+            then.json_body(apps_v1_discovery());
+        });
+        fake_apiserver.handle(|when, then| {
+            when.method(PATCH).path(format!(
+                "/apis/apps/v1/namespaces/{TEST_VIRT_NS_PREFIX}-{TEST_NS_NAME}/deployments/nginx-deployment"
+            ));
+            then.json_body(status_ok());
+        });
+        fake_apiserver.handle(|when, then| {
+            when.method(DELETE).path(format!(
+                "/apis/apps/v1/namespaces/{TEST_VIRT_NS_PREFIX}-{TEST_NS_NAME}/deployments/nginx-deployment-2"
+            ));
+            then.json_body(status_ok());
+        });
+        let sim_handle_id = fake_apiserver.handle(move |when, then| {
+            when.method(GET)
+                .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+            then.json_body_obj(&test_sim);
+        });
+
+        let mut fake_apiserver_clone_1 = fake_apiserver.clone();
+        let paused_ts = 3;
+        clock.add_callback(paused_ts, move || {
+            fake_apiserver_clone_1.drop(sim_handle_id);
+            let mut test_sim_clone = test_sim_clone_1.clone(); // Don't understand why this clone is needed
+            test_sim_clone.spec.paused_time = DateTime::from_timestamp(paused_ts, 0);
+            fake_apiserver_clone_1.handle_multiple(
+                move |when, then| {
+                    when.method(GET)
+                        .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+                    then.json_body_obj(&test_sim_clone);
+                },
+                2,
+            );
+        });
+
+        // The simulation was "supposed" to process its next event at time 10, so that's when
+        // it wakes up; at that point, it realizes that the simulation was paused at time 3,
+        // so it then sleeps until time 20.  Then it wakes up, realizes it's still paused, so
+        // sleeps until time 30.  Then it wakes up, it is unpaused, sleeps for another 7 seconds,
+        // and completes the simulation at time 37.
+        let mut fake_apiserver_clone_2 = fake_apiserver.clone();
+        clock.add_callback(paused_ts + 2 * DRIVER_PAUSED_WAIT_SECONDS, move || {
+            fake_apiserver_clone_2.drop(sim_handle_id + 1);
+            let test_sim_clone = test_sim_clone_2.clone(); // Don't understand why this clone is needed
+            fake_apiserver_clone_2.handle(move |when, then| {
+                when.method(GET)
+                    .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+                then.json_body_obj(&test_sim_clone);
+            });
+        });
+
+        run_trace_internal(&ctx, client, 1.0, root, TRACE_START, clock.clone())
+            .await
+            .unwrap();
+        fake_apiserver.assert();
+        assert_eq!(37, clock.now_ts());
     }
 }

--- a/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@true.snap
+++ b/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@true.snap
@@ -10,7 +10,7 @@ Object {
             "simkube.io/original-namespace": String("test-namespace"),
             "simkube.io/pod-sequence-number": String("0"),
             "simkube.io/pod-spec-stable-hash": String("17506812802394981455"),
-            "simkube.kwok.io/stage-complete-time": String("1970-01-01T00:00:42+00:00"),
+            "simkube.kwok.io/stage-complete-time": String("1970-01-01T00:00:21+00:00"),
         },
         "labels": Object {
             "foo": String("bar"),

--- a/sk-driver/src/tests/util_test.rs
+++ b/sk-driver/src/tests/util_test.rs
@@ -1,0 +1,80 @@
+use clockabilly::mock::MockUtcClock;
+use clockabilly::prelude::*;
+use clockabilly::{
+    DateTime,
+    Utc,
+};
+use httpmock::Method::*;
+
+use super::*;
+use crate::util::{
+    compute_step_size,
+    DRIVER_PAUSED_WAIT_SECONDS,
+};
+
+#[rstest]
+#[case(1.0, 0, 10, 10)]
+#[case(2.0, 0, 10, 5)]
+#[case(1.0, 10, 0, 0)]
+fn test_compute_step_size(#[case] speed: f64, #[case] start_ts: i64, #[case] end_ts: i64, #[case] expected: i64) {
+    let result = compute_step_size(speed, start_ts, end_ts);
+    assert_eq!(expected, result);
+}
+
+#[rstest(tokio::test)]
+async fn test_wait_if_paused_not_paused(test_sim: Simulation) {
+    let (mut fake_apiserver, client) = make_fake_apiserver();
+    let clock = MockUtcClock::boxed(0);
+
+    fake_apiserver.handle(move |when, then| {
+        when.method(GET)
+            .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+        then.json_body_obj(&test_sim);
+    });
+    wait_if_paused(client, TEST_SIM_NAME, clock.clone()).await.unwrap();
+    fake_apiserver.assert();
+    assert_eq!(0, clock.now_ts());
+}
+
+#[rstest(tokio::test)]
+#[case::before_start(DateTime::from_timestamp(-1, 0))]
+#[case::at_start(DateTime::from_timestamp(0, 0))]
+async fn test_wait_if_paused_paused(test_sim: Simulation, #[case] paused_time: Option<DateTime<Utc>>) {
+    // This whole test is really ugly for what it's actually testing; we need to be able to change
+    // the return value from the fake apiserver after some time has passed, right now the only way
+    // to do that is to set up a callback in the fake clock and delete the old mock + insert a new
+    // one.  This could be simplified quite a bit if https://github.com/alexliesenfeld/httpmock/issues/132
+    // is accepted and lands.
+    let (mut fake_apiserver, client) = make_fake_apiserver();
+    let mut clock = MockUtcClock::boxed(0);
+
+    let mut test_sim_paused = test_sim.clone();
+    test_sim_paused.spec.paused_time = paused_time;
+
+    // Return the "paused" simulation state at first
+    let sim_handle_id = fake_apiserver.handle_multiple(
+        move |when, then| {
+            when.method(GET)
+                .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+            then.json_body_obj(&test_sim_paused);
+        },
+        2,
+    );
+
+    // After some time has passed, unpause the simulation
+    let mut fake_apiserver_clone = fake_apiserver.clone();
+    clock.add_callback(DRIVER_PAUSED_WAIT_SECONDS + 1, move || {
+        fake_apiserver_clone.drop(sim_handle_id);
+        let test_sim_clone = test_sim.clone(); // Don't understand why this clone is needed
+        fake_apiserver_clone.handle(move |when, then| {
+            when.method(GET)
+                .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+            then.json_body_obj(&test_sim_clone);
+        });
+    });
+
+    wait_if_paused(client, TEST_SIM_NAME, clock.clone()).await.unwrap();
+
+    assert_eq!(DRIVER_PAUSED_WAIT_SECONDS * 2, clock.now_ts());
+    fake_apiserver.assert();
+}

--- a/sk-driver/src/util.rs
+++ b/sk-driver/src/util.rs
@@ -1,9 +1,52 @@
 use std::cmp::max;
 
-use crate::DriverContext;
+use clockabilly::prelude::*;
+use sk_core::prelude::*;
+use tracing::*;
 
-pub fn compute_step_size(ctx: &DriverContext, start_ts: i64, end_ts: i64) -> u64 {
-    let speed = ctx.sim.spec.speed.unwrap_or(1.0);
+pub(crate) const DRIVER_PAUSED_WAIT_SECONDS: i64 = 10;
+
+pub fn compute_step_size(speed: f64, start_ts: i64, end_ts: i64) -> i64 {
     let normal_step_duration = max(0, end_ts - start_ts) as f64;
-    (normal_step_duration / speed) as u64
+    (normal_step_duration / speed) as i64
+}
+
+// This could be made more efficient and intuitive by using a watcher and message-passing so that we
+// only get notified and pause/unpause if changes are actually made to the simulation object.  But
+// that requires more rearchitecting than I really want to do right now, so for the time being we're
+// just going to poll the apiserver every 10 seconds for changes.
+pub(crate) async fn wait_if_paused(
+    client: kube::Client,
+    sim_name: &str,
+    clock: Box<dyn Clockable + Send>,
+) -> anyhow::Result<i64> {
+    let sim_api: kube::Api<Simulation> = kube::Api::all(client.clone());
+    let mut sim = sim_api.get(sim_name).await?;
+    let mut total_paused_seconds = 0;
+
+    if let Some(mut pause_time) = sim.spec.paused_time {
+        // If the simulation was paused at start, then the pause time will be several seconds
+        // before the current timestamp, which means we end up waiting another few seconds once the
+        // simulation is resumed.  Not a huge deal, but slightly annoying, so we special-case it
+        if sim
+            .status
+            .as_ref()
+            .is_some_and(|st| pause_time < st.start_time.unwrap_or_default())
+        {
+            pause_time = clock.now();
+        }
+
+        debug!("simulation pause time = {pause_time}");
+        let pause_duration = compute_step_size(sim.speed(), pause_time.timestamp(), clock.now_ts());
+        while sim.spec.paused_time.is_some() {
+            info!("simulation is paused, waiting for {DRIVER_PAUSED_WAIT_SECONDS} seconds...");
+            clock.sleep(DRIVER_PAUSED_WAIT_SECONDS).await;
+            total_paused_seconds += DRIVER_PAUSED_WAIT_SECONDS;
+            sim = sim_api.get(sim_name).await?;
+        }
+        info!("simulation resumed; next event happens in {pause_duration} seconds");
+        total_paused_seconds += pause_duration;
+        clock.sleep(pause_duration).await;
+    }
+    Ok(total_paused_seconds)
 }

--- a/sk-driver/src/util.rs
+++ b/sk-driver/src/util.rs
@@ -3,7 +3,7 @@ use std::cmp::max;
 use crate::DriverContext;
 
 pub fn compute_step_size(ctx: &DriverContext, start_ts: i64, end_ts: i64) -> u64 {
-    let speed = ctx.sim.spec.driver.speed;
+    let speed = ctx.sim.spec.speed.unwrap_or(1.0);
     let normal_step_duration = max(0, end_ts - start_ts) as f64;
     (normal_step_duration / speed) as u64
 }

--- a/sk-store/src/lib.rs
+++ b/sk-store/src/lib.rs
@@ -89,6 +89,10 @@ pub struct ExportedTrace {
 }
 
 impl ExportedTrace {
+    pub fn append_event(&mut self, event: TraceEvent) {
+        self.events.push(event);
+    }
+
     pub fn prepend_event(&mut self, event: TraceEvent) {
         let mut tmp = vec![event];
         tmp.append(&mut self.events);

--- a/sk-store/src/store.rs
+++ b/sk-store/src/store.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::bail;
-use clockabilly::{
-    Clockable,
-    UtcClock,
-};
+use clockabilly::prelude::*;
 use sk_api::v1::ExportFilters;
 use sk_core::jsonutils;
 use sk_core::k8s::{

--- a/sk-store/src/watchers/mod.rs
+++ b/sk-store/src/watchers/mod.rs
@@ -13,10 +13,7 @@ use std::sync::{
 };
 
 use async_trait::async_trait;
-use clockabilly::{
-    Clockable,
-    UtcClock,
-};
+use clockabilly::prelude::*;
 use futures::{
     Stream,
     StreamExt,

--- a/testutils/src/sim.rs
+++ b/testutils/src/sim.rs
@@ -18,9 +18,9 @@ pub fn test_sim() -> Simulation {
                 image: "docker.foo:1234/sk-driver:latest".into(),
                 port: 9876,
                 trace_path: "file:///foo/bar".into(),
-                speed: 2.0,
             },
             metrics: Some(Default::default()),
+            speed: Some(2.0),
             hooks: Some(SimulationHooksConfig {
                 pre_start_hooks: Some(vec![SimulationHook {
                     cmd: "echo".into(),

--- a/testutils/src/sim.rs
+++ b/testutils/src/sim.rs
@@ -1,3 +1,4 @@
+use clockabilly::DateTime;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
 use rstest::fixture;
 use sk_api::v1::*;
@@ -20,7 +21,6 @@ pub fn test_sim() -> Simulation {
                 trace_path: "file:///foo/bar".into(),
             },
             metrics: Some(Default::default()),
-            speed: Some(2.0),
             hooks: Some(SimulationHooksConfig {
                 pre_start_hooks: Some(vec![SimulationHook {
                     cmd: "echo".into(),
@@ -36,7 +36,10 @@ pub fn test_sim() -> Simulation {
             }),
             ..Default::default()
         },
-        status: Default::default(),
+        status: Some(SimulationStatus {
+            start_time: DateTime::from_timestamp(0, 0),
+            ..Default::default()
+        }),
     }
 }
 


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Add the ability to pause and resume simulations, by setting a `pausedTime` field on the simulation spec.  When this field is set,

1. The controller marks the state as "Paused" (unless the simulation hasn't initialized -- more on this below)
2. The next time the driver wakes up, it will detect that the simulation is paused and wait until the user unpauses the simulation (by setting the field to null) to continue.

I also added `pause` and `resume` subcommands to the CLI so that you can use it to control the paused status, as well as a `--start-paused` flag to the `run` subcommand.  This will cause the (first) driver pod to be created, but it will not do anything until the user resumes; this lets the user interact with the driver pod (for example, to copy a local trace file into place) before starting the simulation.

This is not a totally complete feature, and probably has a number of bugs in it, but I wanted to get the basis in place and it's already taken me way too long to get this merged.  Notably, if you pause and unpause the simulation in the intervening period between events, the driver will not notice and act like nothing happened


## Testing done
- make test
- manual testing
