### PR TITLE
Drmorr/sk 35 add skip local volume mount flag to cli

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,6 @@ inherits = "dev"
 [profile.skctl-release]
 inherits = "release"
 
-[profile.test-cover]
+[profile.nextest]
 inherits = "test"
 incremental = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3581,6 +3581,7 @@ name = "sk-ctrl"
 version = "2.2.0"
 dependencies = [
  "anyhow",
+ "assertables",
  "clap",
  "clockabilly",
  "futures",

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CARGO=CARGO_HOME=$(BUILD_DIR)/cargo cargo
 COVERAGE_IGNORES+=sk-api/.* testutils/.*
 EXCLUDE_CRATES=sk-testutils
 RUST_LOG=warn,sk_api,sk_core,sk_store,sk_tracer,sk_ctrl,sk_driver,sk_cli,httpmock=debug
+CARGO_PROFILE = nextest
 
 ifndef IN_CI
 DOCKER_ARGS=-it --init

--- a/k8s/kustomize/sim/simkube.io_simulations.yml
+++ b/k8s/kustomize/sim/simkube.io_simulations.yml
@@ -49,6 +49,11 @@ spec:
             properties:
               driver:
                 properties:
+                  args:
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
                   image:
                     type: string
                   namespace:

--- a/k8s/raw/simkube.io_simulations.yml
+++ b/k8s/raw/simkube.io_simulations.yml
@@ -49,6 +49,11 @@ spec:
             properties:
               driver:
                 properties:
+                  args:
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
                   image:
                     type: string
                   namespace:

--- a/sk-api/src/v1/simulations.rs
+++ b/sk-api/src/v1/simulations.rs
@@ -29,6 +29,7 @@ pub struct SimulationDriverConfig {
     pub image: String,
     pub trace_path: String,
     pub port: i32,
+    pub args: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]

--- a/sk-core/src/constants.rs
+++ b/sk-core/src/constants.rs
@@ -13,6 +13,7 @@ pub const SIMULATION_LABEL_KEY: &str = "simkube.io/simulation";
 pub const VIRTUAL_LABEL_KEY: &str = "simkube.io/virtual";
 pub const POD_SPEC_STABLE_HASH_KEY: &str = "simkube.io/pod-spec-stable-hash";
 pub const POD_SEQUENCE_NUMBER_KEY: &str = "simkube.io/pod-sequence-number";
+pub const SKIP_LOCAL_VOLUME_MOUNT_ANNOTATION_KEY: &str = "simkube.io/skip-local-volue-mount";
 
 // Lifecycle management labels and annotations
 pub const KWOK_STAGE_COMPLETE_KEY: &str = "simkube.kwok.io/stage-complete";

--- a/sk-ctrl/Cargo.toml
+++ b/sk-ctrl/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+assertables = { workspace = true }
 httpmock = { workspace = true }
 rstest = { workspace = true }
 rstest-log = { workspace = true }

--- a/sk-ctrl/src/main.rs
+++ b/sk-ctrl/src/main.rs
@@ -29,7 +29,7 @@ use crate::controller::{
     reconcile,
 };
 
-#[derive(Clone, Debug, Parser)]
+#[derive(Clone, Debug, Default, Parser)]
 struct Options {
     #[arg(long, value_delimiter = ',')]
     driver_secrets: Option<Vec<String>>,

--- a/sk-ctrl/src/tests/mod.rs
+++ b/sk-ctrl/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod controller_test;
+mod objects_test;
 
 use sk_core::prelude::*;
 use sk_testutils::*;

--- a/sk-ctrl/src/tests/objects_test.rs
+++ b/sk-ctrl/src/tests/objects_test.rs
@@ -1,0 +1,40 @@
+use std::env;
+
+use assertables::*;
+
+use super::*;
+use crate::objects::build_driver_job;
+
+#[rstest(tokio::test)]
+async fn test_build_driver_job_with_extra_args(mut test_sim: Simulation) {
+    // this_is_fine.jpg
+    unsafe {
+        env::set_var(POD_SVC_ACCOUNT_ENV_VAR, TEST_SERVICE_ACCOUNT);
+    }
+
+    test_sim.spec.driver.args = Some(vec!["--foo".into(), "bar".into(), "--baz".into()]);
+    let (_, client) = make_fake_apiserver();
+    let ctx = SimulationContext::new(client, Default::default());
+    let job = build_driver_job(&ctx, &test_sim, None, "secret", TEST_NAMESPACE).unwrap();
+
+    let job_spec = job.spec.unwrap().template.spec.unwrap();
+    let args = job_spec.containers.get(0).unwrap().args.as_ref().unwrap();
+    let expected_args: Vec<&str> = vec![
+        "--cert-path",
+        "/usr/local/etc/ssl/tls.crt",
+        "--key-path",
+        "/usr/local/etc/ssl/tls.key",
+        "--trace-path",
+        "/foo/bar",
+        "--virtual-ns-prefix",
+        "virtual",
+        "--sim-name",
+        "",
+        "--controller-ns",
+        "test-namespace",
+        "--foo",
+        "bar",
+        "--baz",
+    ];
+    assert_iter_eq!(expected_args, args);
+}

--- a/sk-ctrl/src/tests/objects_test.rs
+++ b/sk-ctrl/src/tests/objects_test.rs
@@ -1,9 +1,14 @@
 use std::env;
 
 use assertables::*;
+use tracing_test::traced_test;
 
 use super::*;
-use crate::objects::build_driver_job;
+use crate::objects::{
+    build_driver_job,
+    build_local_trace_volume,
+    TRACE_VOLUME_NAME,
+};
 
 #[rstest(tokio::test)]
 async fn test_build_driver_job_with_extra_args(mut test_sim: Simulation) {
@@ -19,7 +24,7 @@ async fn test_build_driver_job_with_extra_args(mut test_sim: Simulation) {
 
     let job_spec = job.spec.unwrap().template.spec.unwrap();
     let args = job_spec.containers.get(0).unwrap().args.as_ref().unwrap();
-    let expected_args: Vec<&str> = vec![
+    let expected: Vec<&str> = vec![
         "--cert-path",
         "/usr/local/etc/ssl/tls.crt",
         "--key-path",
@@ -36,5 +41,47 @@ async fn test_build_driver_job_with_extra_args(mut test_sim: Simulation) {
         "bar",
         "--baz",
     ];
-    assert_iter_eq!(expected_args, args);
+    assert_iter_eq!(args, expected);
+}
+
+#[rstest]
+fn test_build_local_trace_volume_not_local(mut test_sim: Simulation) {
+    test_sim.spec.driver.trace_path = "s3://foo/bar".into();
+    let res = build_local_trace_volume(&test_sim).unwrap();
+    assert_none!(res);
+}
+
+#[rstest]
+fn test_build_local_trace_volume_skip_volume_mount(mut test_sim: Simulation) {
+    test_sim
+        .annotations_mut()
+        .insert(SKIP_LOCAL_VOLUME_MOUNT_ANNOTATION_KEY.into(), "true".into());
+    let res = build_local_trace_volume(&test_sim).unwrap();
+    assert_none!(res);
+}
+
+#[rstest]
+#[traced_test]
+fn test_build_local_trace_volume_skip_volume_mount_not_local(mut test_sim: Simulation) {
+    test_sim
+        .annotations_mut()
+        .insert(SKIP_LOCAL_VOLUME_MOUNT_ANNOTATION_KEY.into(), "true".into());
+    test_sim.spec.driver.trace_path = "s3://foo/bar".into();
+    let res = build_local_trace_volume(&test_sim).unwrap();
+    assert_none!(res);
+    assert!(logs_contain("ignoring annotation"));
+}
+
+#[rstest]
+fn test_build_local_trace_volume(test_sim: Simulation) {
+    let res = build_local_trace_volume(&test_sim).unwrap();
+    let (mount, volume, path) = res.unwrap();
+
+    assert_eq!(mount.name, TRACE_VOLUME_NAME);
+    assert_eq!(mount.mount_path, "/foo/bar");
+    assert_eq!(volume.name, TRACE_VOLUME_NAME);
+    let host_path = volume.host_path.unwrap();
+    assert_eq!(host_path.path, "/foo/bar");
+    assert_eq!(host_path.type_, Some("File".into()));
+    assert_eq!(path, "/foo/bar");
 }

--- a/sk-driver/src/main.rs
+++ b/sk-driver/src/main.rs
@@ -44,6 +44,7 @@ struct Options {
     #[arg(long)]
     sim_name: String,
 
+    // Needed so the driver can update the lease
     #[arg(long)]
     controller_ns: String,
 
@@ -52,9 +53,6 @@ struct Options {
 
     #[arg(long, default_value = DRIVER_ADMISSION_WEBHOOK_PORT)]
     admission_webhook_port: u16,
-
-    #[arg(long, default_value = "1.0")]
-    speed: f64,
 
     #[arg(long)]
     cert_path: String,

--- a/testutils/src/sim.rs
+++ b/testutils/src/sim.rs
@@ -19,6 +19,7 @@ pub fn test_sim() -> Simulation {
                 image: "docker.foo:1234/sk-driver:latest".into(),
                 port: 9876,
                 trace_path: "file:///foo/bar".into(),
+                args: None,
             },
             metrics: Some(Default::default()),
             hooks: Some(SimulationHooksConfig {


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
- `--skip-local-volume-mount` CLI flag
- specify arbitrary driver args in the simulation spec
- fix nextest cached files location

## Testing done
- manual testing
- adding tests for build volume mounts and build driver job args
