### PR TITLE
fix: export_all off-by-one error

### DIFF
--- a/sk-store/src/event_list.rs
+++ b/sk-store/src/event_list.rs
@@ -10,7 +10,7 @@ use crate::{
     TraceEvent,
 };
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct TraceEventList(VecDeque<TraceEvent>);
 
 impl TraceEventList {

--- a/sk-store/src/store.rs
+++ b/sk-store/src/store.rs
@@ -94,7 +94,7 @@ impl TraceStore {
         let (Some(start_ts), Some(end_ts)) = (self.start_ts(), self.end_ts()) else {
             return Ok(vec![]);
         };
-        self.export(start_ts, end_ts, &ExportFilters::default())
+        self.export(start_ts, end_ts + 1, &ExportFilters::default())
     }
 
     pub fn import(data: Vec<u8>, maybe_duration: &Option<String>) -> anyhow::Result<TraceStore> {

--- a/sk-store/src/tests/trace_store_test.rs
+++ b/sk-store/src/tests/trace_store_test.rs
@@ -32,6 +32,14 @@ fn owner_ref() -> metav1::OwnerReference {
 }
 
 #[rstest]
+fn test_export_all(mut tracer: TraceStore, test_deployment: DynamicObject) {
+    tracer.create_or_update_obj(&test_deployment, 1, None).unwrap();
+    let export_data = tracer.export_all().unwrap();
+    let new_trace = TraceStore::import(export_data, &None).unwrap();
+    assert_len_eq_x!(new_trace.events, 2); // start marker + the deployment event
+}
+
+#[rstest]
 fn test_lookup_pod_lifecycle_no_owner(tracer: TraceStore) {
     let res = tracer.lookup_pod_lifecycle(&DEPL_GVK, TEST_DEPLOYMENT, EMPTY_POD_SPEC_HASH, 0);
     assert_eq!(res, PodLifecycleData::Empty);


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
`export_all` used end_ts, which is the last timestamp of an event in the trace; but export is end-ts-exclusive, so we need to add one here.

## Testing done
- make test
- manual testing
