### PR TITLE
ci: pin nightly version

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,6 +15,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: sccache
   IN_CI: "true"
+  RUST_NIGHTLY_VERSION: 2024-10-29
 
 jobs:
   skctl:
@@ -61,10 +62,10 @@ jobs:
           submodules: recursive
       - name: Setup Builder
         uses: ./.github/actions/setup-builder
-      - name: rustfmt nightly
+      - name: Install rustfmt nightly
         run: |
-          rustup toolchain install nightly-x86_64-unknown-linux-gnu
-          rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly-${RUST_NIGHTLY_VERSION}
+          rustup component add rustfmt --toolchain nightly-${RUST_NIGHTLY_VERSION}
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -86,6 +87,9 @@ jobs:
           submodules: recursive
       - name: Setup Builder
         uses: ./.github/actions/setup-builder
+      - name: Install Rust nightly
+        run: |
+          rustup toolchain install nightly-${RUST_NIGHTLY_VERSION}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cargo-nextest
       - name: Install cargo-llvm-cov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,13 @@ repos:
           - --
           - -Dwarnings
           - -Aclippy::new_without_default
-  - repo: "https://github.com/futuretech6/pre-commit-rust-nightly"
-    rev: v1.1
+  - repo: local
     hooks:
       - id: fmt
         name: rust-fmt
-        args: ['--', '--unstable-features']
+        language: system
+        entry: hack/fmt
+        files: \.rs
   - repo: "https://github.com/pre-commit/mirrors-mypy"
     rev: v1.4.1
     hooks:

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -13,10 +13,14 @@ Kind).
 In addition to the project prerequisites, you will need to have the following installed:
 
 - [pre-commit](https://pre-commit.com)
-- Nightly version of rustfmt
 - [cargo-nextext](https://nexte.st) for running tests
-- Nightly version of [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) for running tests
 - [cargo-insta](https://insta.rs/docs/quickstart/) (only needed for updating/adding new snapshot tests)
+- Nightly version of rustfmt
+- (optional) Nightly version of [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) for generating code coverage
+
+The current nightly Rust version used is 2024-10-29, which corresponds (approximately) to the Rust 1.83 release; this is
+pinned in CI; you'll want to set the `RUST_NIGHTLY_VERSION` environment variable to this value so that you can match the
+CI behaviour locally.
 
 SimKube uses [🔥Config](https://github.com/acrlabs/fireconfig) to generate Kubernetes manifests from definitions located
 in `./k8s/`.  If you want to make changes to the generated Kubernetes manifests, you will need to install the

--- a/hack/fmt
+++ b/hack/fmt
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+cargo +nightly-${RUST_NIGHTLY_VERSION} fmt -- --unstable-features $@


### PR DESCRIPTION
- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Pin Rust nightly version so we don't get lints/checks failing that don't match local
