### PR TITLE
don't hard-crash on owner lookup failure

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 array_width = 100
 blank_lines_upper_bound = 2
 chain_width = 80


### PR DESCRIPTION
## Related Links
- https://linear.app/acrl/issue/SK-63/export-is-broken-on-permissions
- https://linear.app/acrl/issue/SK-62/longunreadable-message

## What
- Export now works even if the owned objects are inaccessible
- The logging messages are readable

## Why
Bugfixes

## Test Steps
What are all the steps to testing your code changes?
- [x] Manual testing

---

- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.