### PR TITLE
fix(ci): update workflow triggers for automated docs publishing

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - 'docs/**'
-      - 'README.md'
+      - 'CHANGELOG.md'
     branches:
       - 'master'
 jobs:


### PR DESCRIPTION
- [ x ] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

## Description
Updates the `publish_docs` workflow trigger to trigger on updates to `docs/` or `CHANGELOG.md` but not `README.md`

## Testing done
- very minor
- will test on next SK release!

## Additional info
Resolves acrl-190
