### PR TITLE
sk-195 // ensure local images used in E2E test

### DIFF
--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -28,6 +28,7 @@ jobs:
           simkube-runner-pat: ${{ secrets.SIMKUBE_RUNNER_PAT }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          keep-alive: true
 
   simkube-e2e-test:
     needs: launch-runner

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -68,6 +68,7 @@ jobs:
           for POD in "${PODS[@]}"; do
             echo "Inspecting pod: $POD..."
             POD_NAME=$(kubectl get pod \
+              --field-selector=status.phase=Running \
               -l app.kubernetes.io/name="$POD" \
               -n simkube \
               -o jsonpath='{.items[0].metadata.name}')
@@ -86,11 +87,6 @@ jobs:
 
             echo "✅ $POD image is from local registry"
           done
-
-      - name: Stabilize
-        shell: bash
-        run: |
-          sleep 5
 
       - name: Final cluster state
         run: |

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -67,7 +67,7 @@ jobs:
           )
 
           for POD in "${PODS[@]}"; do
-            echo "Inspecting pod: "$POD"..."
+            echo "Inspecting pod: $POD..."
             POD_NAME=$(kubectl get pod \
               -l app.kubernetes.io/name="$POD" \
               -n simkube \
@@ -86,6 +86,7 @@ jobs:
             fi
 
             echo "✅ $POD from local registry"
+          done
 
       - name: Stabilize
         shell: bash

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -88,12 +88,6 @@ jobs:
             echo "✅ $POD image is from local registry"
           done
 
-      - name: Final cluster state
-        run: |
-          kubectl get pods -n simkube -o wide
-          kubectl get pods -n simkube \
-            -o jsonpath='{.items[*].spec.containers[*].image}'
-
       - name: Get driver image
         id: get_driver_image
         shell: bash
@@ -111,8 +105,6 @@ jobs:
             echo "❌ Driver image is not from local registry: $IMAGE"
             exit 1
           fi
-
-          echo "✅ Driver image is from local registry"
 
           echo "Driver image: $IMAGE"
           echo "driver_image=$IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -85,7 +85,7 @@ jobs:
               exit 1
             fi
 
-            echo "✅ $POD from local registry"
+            echo "✅ $POD image is from local registry"
           done
 
       - name: Stabilize
@@ -99,8 +99,32 @@ jobs:
           kubectl get pods -n simkube \
             -o jsonpath='{.items[*].spec.containers[*].image}'
 
+      - name: Get driver image
+        id: get_driver_image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f .build/sk-driver-image ]]; then
+            echo "❌ Missing .build/sk-driver-image"
+            exit 1
+          fi
+
+          IMAGE=$(cat .build/sk-driver-image)
+
+          if [[ "$IMAGE" != localhost:5000/* ]]; then
+            echo "❌ Driver image is not from local registry: $IMAGE"
+            exit 1
+          fi
+
+          echo "✅ Driver image is from local registry"
+
+          echo "Driver image: $IMAGE"
+          echo "driver_image=$IMAGE" >> "$GITHUB_OUTPUT"
+
       - name: Run simulation
         uses: acrlabs/simkube-ci-action/actions/run-simulation@main
         with:
           simulation-name: test-cronjob-sim
           trace-path: examples/traces/cronjob.sktrace
+          driver-image: ${{ steps.get_driver_image.outputs.driver_image }}

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -42,34 +42,62 @@ jobs:
       - name: Add .local/bin to PATH
         run: echo "/home/ubuntu/.local/bin" >> $GITHUB_PATH
       - name: Build
-        run: make
-      - name: Verify image is from local registry
+        run: make build image run
+      - name: Wait for cluster rollout
         shell: bash
         run: |
           set -euo pipefail
 
-          echo "Waiting for rollout to complete..."
-          kubectl rollout status deployment/sk-ctrl-depl \
-             -n simkube
+          echo "Waiting for simkube deployments..."
+          for d in $(kubectl get deploy -n simkube -o name); do
+            echo "Waiting for $d"
+            kubectl rollout status $d -n simkube --timeout=120s
+          done
 
-          POD_NAME=$(kubectl get pod \
-            -l app.kubernetes.io/name=sk-ctrl \
-            -n simkube \
-            -o jsonpath='{.items[0].metadata.name}')
+          echo "All deployments rolled out"
 
-          IMAGE_ID=$(kubectl get pod "$POD_NAME" \
-            -n simkube \
-            -o jsonpath='{.status.containerStatuses[0].imageID}')
+      - name: Verify simkube images are from local registry
+        shell: bash
+        run: |
+          set -euo pipefail
 
-          echo "Pod: $POD_NAME"
-          echo "Image ID: $IMAGE_ID"
+          PODS=(
+            sk-ctrl
+            sk-driver
+          )
 
-          if ! echo "$IMAGE_ID" | grep -q "localhost:5000"; then
-            echo "❌ Image NOT from local registry"
-            exit 1
-          fi
+          for POD in "${PODS[@]}"; do
+            echo "Inspecting pod: "$POD"..."
+            POD_NAME=$(kubectl get pod \
+              -l app.kubernetes.io/name="$POD" \
+              -n simkube \
+              -o jsonpath='{.items[0].metadata.name}')
 
-          echo "✅ Image from local registry"
+            IMAGE_ID=$(kubectl get pod "$POD_NAME" \
+              -n simkube \
+              -o jsonpath='{.status.containerStatuses[0].imageID}')
+
+            echo "Pod: $POD_NAME"
+            echo "Image ID: $IMAGE_ID"
+
+            if ! echo "$IMAGE_ID" | grep -q "localhost:5000"; then
+              echo "❌ Image NOT from local registry"
+              exit 1
+            fi
+
+            echo "✅ $POD from local registry"
+
+      - name: Stabilize
+        shell: bash
+        run: |
+          sleep 5
+
+      - name: Final cluster state
+        run: |
+          kubectl get pods -n simkube -o wide
+          kubectl get pods -n simkube \
+            -o jsonpath='{.items[*].spec.containers[*].image}'
+
       - name: Run simulation
         uses: acrlabs/simkube-ci-action/actions/run-simulation@main
         with:

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Verify simkube images are from local registry
         shell: bash
         run: |
-          set -euo pipefail
+          set -exuo pipefail
 
           PODS=(
             sk-ctrl

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Verify simkube images are from local registry
         shell: bash
         run: |
-          set -exuo pipefail
+          set -euo pipefail
 
           PODS=(
             sk-ctrl

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -28,7 +28,6 @@ jobs:
           simkube-runner-pat: ${{ secrets.SIMKUBE_RUNNER_PAT }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          keep-alive: true
 
   simkube-e2e-test:
     needs: launch-runner

--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -63,7 +63,7 @@ jobs:
 
           PODS=(
             sk-ctrl
-            sk-driver
+            sk-tracer
           )
 
           for POD in "${PODS[@]}"; do


### PR DESCRIPTION
## Related Links
<!-- include a link to the issue(s) this resolves and/or any related design docs -->
- https://linear.app/acrl/issue/SK-195/e2e-test-failed-in-sk-repo

## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- our e2e test failed
- we noticed that none of our local images (from the branch) were being used in the E2E test, all were defaulting
- we had previously added a check (for sk-ctrl) to check for local images, which caused the E2E test to fail

## How
<!-- if the changes are not obvious/straightforward, explain how you approached the problem -->
- added more robust logging and checks for sk-ctrl, sk-driver and sk-tracer in the E2E test setup
- instead of using the default `make` target I specified the full `make build image run`
- set `driver-image` explicitly via options in our `run-simulation` action so it doesn't default

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- via our E2E test
- original failure - https://github.com/acrlabs/simkube/actions/runs/23318868613/job/67825479417
- updated re-run - https://github.com/acrlabs/simkube/actions/runs/23615732077

## Other Notes
<!-- any other notes/comments/feedback/suggestions that will help your reviewers out -->
- N/A

- [ x ] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
