### PR TITLE
Feat/skctl simulation details 59

### DIFF
--- a/sk-cli/src/info.rs
+++ b/sk-cli/src/info.rs
@@ -1,0 +1,91 @@
+use anyhow::bail;
+use clockabilly::{DateTime, Utc};
+use serde::Serialize;
+use sk_api::v1::{SimulationDriverConfig, SimulationHooksConfig, SimulationMetricsConfig, SimulationState};
+use sk_core::prelude::*;
+
+#[derive(clap::Args, Debug)]
+pub struct Args {
+    #[arg(long_help = "name of the simulation to inspect")]
+    pub name: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SimulationInfo {
+    name: String,
+    state: Option<SimulationState>,
+    start_time: Option<DateTime<Utc>>,
+    end_time: Option<DateTime<Utc>>,
+    completed_runs: Option<u64>,
+    total_runs: Option<i32>,
+    speed: f64,
+    paused_time: Option<DateTime<Utc>>,
+    driver: SimulationDriverConfig,
+    metrics: Option<SimulationMetricsConfig>,
+    hooks: Option<SimulationHooksConfig>,
+}
+
+pub async fn cmd(args: &Args, client: kube::Client) -> EmptyResult {
+    let sim_api = kube::Api::<Simulation>::all(client);
+    let sim = sim_api.get_opt(&args.name).await?;
+
+    let sim = match sim {
+        Some(sim) => sim,
+        None => bail!("simulation not found: {}", args.name),
+    };
+
+    let status = sim.status.clone().unwrap_or_default();
+
+    let info = SimulationInfo {
+        name: sim.metadata.name.clone().unwrap_or_else(|| args.name.clone()),
+        state: status.state,
+        start_time: status.start_time,
+        end_time: status.end_time,
+        completed_runs: status.completed_runs,
+        total_runs: sim.spec.repetitions,
+        speed: sim.speed(),
+        paused_time: sim.spec.paused_time,
+        driver: sim.spec.driver,
+        metrics: sim.spec.metrics,
+        hooks: sim.spec.hooks,
+    };
+
+    println!("{}", serde_yaml::to_string(&info)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use assertables::*;
+    use sk_testutils::*;
+
+    use super::*;
+
+    #[rstest(tokio::test)]
+    async fn test_info_cmd_not_found() {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+        fake_apiserver.handle_not_found(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+
+        let err = cmd(&Args { name: TEST_SIM_NAME.into() }, client).await.unwrap_err();
+
+        assert_eq!(format!("simulation not found: {TEST_SIM_NAME}"), format!("{}", err.root_cause()));
+
+        fake_apiserver.assert();
+    }
+
+    #[rstest(tokio::test)]
+    async fn test_info_cmd_ok(test_sim: Simulation) {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+
+        fake_apiserver.handle(move |when, then| {
+            when.method(GET)
+                .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
+            then.json_body_obj(&test_sim);
+        });
+
+        cmd(&Args { name: TEST_SIM_NAME.into() }, client).await.unwrap();
+
+        fake_apiserver.assert();
+    }
+}

--- a/sk-cli/src/list.rs
+++ b/sk-cli/src/list.rs
@@ -1,0 +1,80 @@
+use sk_core::prelude::*;
+
+#[derive(clap::Args, Debug, Default)]
+pub struct Args {}
+
+fn fmt_dt(ts: Option<clockabilly::DateTime<clockabilly::Utc>>) -> String {
+    ts.map(|t| t.to_string()).unwrap_or_else(|| "-".into())
+}
+
+fn fmt_state(sim: &Simulation) -> String {
+    sim.status
+        .as_ref()
+        .and_then(|s| s.state.as_ref())
+        .map(|s| format!("{s:?}").to_lowercase())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn fmt_completed(sim: &Simulation) -> String {
+    let completed = sim.status.as_ref().and_then(|s| s.completed_runs).unwrap_or(0);
+    let total = sim.spec.repetitions.unwrap_or(1);
+    format!("{completed}/{total}")
+}
+
+pub async fn cmd(_: &Args, client: kube::Client) -> EmptyResult {
+    let sim_api = kube::Api::<Simulation>::all(client);
+    let mut sims = sim_api.list(&Default::default()).await?.items;
+
+    if sims.is_empty() {
+        println!("no simulations found");
+        return Ok(());
+    }
+
+    sims.sort_by(|a, b| {
+        a.metadata
+            .name
+            .as_deref()
+            .unwrap_or("")
+            .cmp(b.metadata.name.as_deref().unwrap_or(""))
+    });
+
+    println!("{:<32} {:<12} {:<24} {:<24} {:<12} {:<8}", "NAME", "STATE", "START", "END", "COMPLETED", "SPEED");
+
+    for sim in sims {
+        let name = sim.metadata.name.as_deref().unwrap_or("-");
+        let start = fmt_dt(sim.status.as_ref().and_then(|s| s.start_time));
+        let end = fmt_dt(sim.status.as_ref().and_then(|s| s.end_time));
+        let completed = fmt_completed(&sim);
+        let speed = sim.speed();
+
+        println!("{:<32} {:<12} {:<24} {:<24} {:<12} {:<8}", name, fmt_state(&sim), start, end, completed, speed);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use sk_testutils::*;
+
+    use super::*;
+
+    #[rstest(tokio::test)]
+    async fn test_list_cmd_ok(test_sim: Simulation) {
+        let (mut fake_apiserver, client) = make_fake_apiserver();
+
+        fake_apiserver.handle(move |when, then| {
+            when.method(GET).path("/apis/simkube.io/v1/simulations");
+            then.json_body_obj(&json!({
+                "kind": "SimulationList",
+                "apiVersion": "simkube.io/v1",
+                "metadata": {},
+                "items": [test_sim],
+            }));
+        });
+
+        cmd(&Args::default(), client).await.unwrap();
+        fake_apiserver.assert();
+    }
+}

--- a/sk-cli/src/main.rs
+++ b/sk-cli/src/main.rs
@@ -14,7 +14,12 @@ mod validation;
 mod xray;
 
 use blackbox_metrics::BlackboxRecorder;
-use clap::{CommandFactory, Parser, Subcommand, crate_version};
+use clap::{
+    CommandFactory,
+    Parser,
+    Subcommand,
+    crate_version,
+};
 use sk_core::logging;
 use sk_core::prelude::*;
 

--- a/sk-cli/src/main.rs
+++ b/sk-cli/src/main.rs
@@ -3,6 +3,8 @@ mod completions;
 mod crd;
 mod delete;
 mod export;
+mod info;
+mod list;
 mod pauseresume;
 mod run;
 mod skel;
@@ -12,12 +14,7 @@ mod validation;
 mod xray;
 
 use blackbox_metrics::BlackboxRecorder;
-use clap::{
-    CommandFactory,
-    Parser,
-    Subcommand,
-    crate_version,
-};
+use clap::{CommandFactory, Parser, Subcommand, crate_version};
 use sk_core::logging;
 use sk_core::prelude::*;
 
@@ -84,6 +81,12 @@ enum SkSubcommand {
 
     #[command(about = "explore or prepare trace data for simulation")]
     Xray(xray::Args),
+
+    #[command(about = "show a summary of simulations", visible_alias = "ls")]
+    List(list::Args),
+
+    #[command(about = "show detailed information about a simulation", visible_alias = "i")]
+    Info(info::Args),
 }
 
 #[tokio::main]
@@ -129,5 +132,14 @@ async fn main() -> EmptyResult {
             Ok(())
         },
         SkSubcommand::Xray(args) => xray::cmd(args).await,
+
+        SkSubcommand::List(args) => {
+            let client = kube::Client::try_default().await?;
+            list::cmd(args, client).await
+        },
+        SkSubcommand::Info(args) => {
+            let client = kube::Client::try_default().await?;
+            info::cmd(args, client).await
+        },
     }
 }

--- a/sk-ctrl/src/main.rs
+++ b/sk-ctrl/src/main.rs
@@ -7,10 +7,18 @@ mod objects;
 use std::sync::Arc;
 
 use clap::Parser;
-use futures::{StreamExt, TryStreamExt, future};
+use futures::{
+    StreamExt,
+    TryStreamExt,
+    future,
+};
 use k8s_openapi::api::batch::v1 as batchv1;
 use kube::runtime::controller::Controller;
-use kube::runtime::{WatchStreamExt, reflector, watcher};
+use kube::runtime::{
+    WatchStreamExt,
+    reflector,
+    watcher,
+};
 use sk_core::logging;
 use sk_core::prelude::*;
 use tracing::*;

--- a/sk-ctrl/src/main.rs
+++ b/sk-ctrl/src/main.rs
@@ -24,7 +24,10 @@ use sk_core::prelude::*;
 use tracing::*;
 
 use crate::context::SimulationContext;
-use crate::controller::{error_policy, reconcile};
+use crate::controller::{
+    error_policy,
+    reconcile,
+};
 
 #[derive(Clone, Debug, Default, Parser)]
 struct Options {

--- a/sk-ctrl/src/main.rs
+++ b/sk-ctrl/src/main.rs
@@ -7,27 +7,16 @@ mod objects;
 use std::sync::Arc;
 
 use clap::Parser;
-use futures::{
-    StreamExt,
-    TryStreamExt,
-    future,
-};
+use futures::{StreamExt, TryStreamExt, future};
 use k8s_openapi::api::batch::v1 as batchv1;
 use kube::runtime::controller::Controller;
-use kube::runtime::{
-    WatchStreamExt,
-    reflector,
-    watcher,
-};
+use kube::runtime::{WatchStreamExt, reflector, watcher};
 use sk_core::logging;
 use sk_core::prelude::*;
 use tracing::*;
 
 use crate::context::SimulationContext;
-use crate::controller::{
-    error_policy,
-    reconcile,
-};
+use crate::controller::{error_policy, reconcile};
 
 #[derive(Clone, Debug, Default, Parser)]
 struct Options {


### PR DESCRIPTION
## Related Links
[Issue 59](https://github.com/acrlabs/simkube/issues/59)

## Description and Rationale
- Added `skctl simulation list` command to display available or currently running simulations  
  → Makes it easier for users to discover simulations without querying lower-level resources  

- Added `skctl simulation info` command to show detailed metadata about a specific simulation  
  → Improves visibility into simulation state, configuration, and runtime details  

- Enhanced CLI output formatting for better readability  
  → Reduces friction when debugging or inspecting simulations from the command line  

## How
- Introduced new subcommands under the `simulation` namespace in `skctl`
- Wired command handlers into the CLI using the existing command structure (`clap`-based parsing)
- Reused existing simulation data sources and extended them to expose additional fields where needed
- Structured output to provide a clear summary (list) and detailed view (info)
