### PR TITLE
SK-216: delete command for SKEL

### DIFF
--- a/docs/ref/skel.md
+++ b/docs/ref/skel.md
@@ -9,6 +9,16 @@ for more details.  The full SKEL grammar is available [on GitHub](https://github
 
 ## Transform operations
 
+### Delete
+
+The `delete` operation deletes any (entire) object that matches the selector:
+
+```text
+delete(<selector>);
+```
+
+Note the difference between `delete` and `remove`, where `remove` only removes fields _within_ a matching resource.
+
 ### Modify
 
 The `modify` operation modifies the specified target fields in the matched trace events:

--- a/sk-cli/src/skel/ast.rs
+++ b/sk-cli/src/skel/ast.rs
@@ -60,12 +60,13 @@ pub(super) enum TraceSelector {
 
 #[derive(Debug, Eq, PartialEq)]
 pub(super) enum CommandAction {
-    Apply(String, Rhs),
+    Delete,
+    Modify(String, Rhs),
     Remove(String),
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub(super) struct Command {
+pub struct Command {
     pub(super) trace_selector: TraceSelector,
     pub(super) action: CommandAction,
 }
@@ -75,10 +76,25 @@ pub(super) fn parse_command(cmd: Pair<Rule>, trace_start_ts: i64) -> anyhow::Res
     let args = cmd.into_inner();
 
     Ok(match rule {
+        Rule::delete_cmd => parse_delete_command(args, trace_start_ts)?,
         Rule::modify_cmd => parse_modify_command(args, trace_start_ts)?,
         Rule::remove_cmd => parse_remove_command(args, trace_start_ts)?,
         x => unreachable!("Rule::{x:?}"),
     })
+}
+
+pub(super) fn parse_delete_command(mut args: Pairs<Rule>, trace_start_ts: i64) -> anyhow::Result<Command> {
+    let mut defined_vars = HashSet::new();
+    let ts = args.next().unwrap();
+    let trace_selector = match ts.as_rule() {
+        // It is _technically_ possible to delete everything in a trace, though I don't know why you
+        // would want to...
+        Rule::trace_selector_all => TraceSelector::All,
+        Rule::trace_selector_list => parse_trace_selector(ts, trace_start_ts, &mut defined_vars)?,
+        x => unreachable!("Rule::{x:?}"),
+    };
+
+    Ok(Command { trace_selector, action: CommandAction::Delete })
 }
 
 pub(super) fn parse_modify_command(mut args: Pairs<Rule>, trace_start_ts: i64) -> anyhow::Result<Command> {
@@ -104,7 +120,7 @@ pub(super) fn parse_modify_command(mut args: Pairs<Rule>, trace_start_ts: i64) -
 
     Ok(Command {
         trace_selector,
-        action: CommandAction::Apply(resource_ptr, rhs),
+        action: CommandAction::Modify(resource_ptr, rhs),
     })
 }
 

--- a/sk-cli/src/skel/engine.rs
+++ b/sk-cli/src/skel/engine.rs
@@ -35,8 +35,10 @@ pub(super) fn process_event(cmd: &Command, mut evt: TraceEvent) -> anyhow::Resul
         process_event_obj(cmd, obj, evt.ts)?
     }
 
-    evt.applied_objs = serde_json::from_value(applied_objs)?;
-    evt.deleted_objs = serde_json::from_value(deleted_objs)?;
+    // trim_event_objects removes all the null entries for deleted elements; then, if there are no
+    // objects left in either field we just prune the entire event
+    evt.applied_objs = serde_json::from_value(trim_event_objects(applied_objs))?;
+    evt.deleted_objs = serde_json::from_value(trim_event_objects(deleted_objs))?;
     Ok(evt)
 }
 
@@ -46,7 +48,8 @@ fn process_event_obj(cmd: &Command, obj: &mut Value, evt_ts: i64) -> EmptyResult
     if trace_matches(&cmd.trace_selector, evt_ts, &mut ctx)? {
         matched_counter.increment(1);
         match &cmd.action {
-            CommandAction::Apply(ptr_str, rhs) => process_modify_event_obj(obj, ptr_str, rhs, &ctx)?,
+            CommandAction::Delete => *obj = Value::Null,
+            CommandAction::Modify(ptr_str, rhs) => process_modify_event_obj(obj, ptr_str, rhs, &ctx)?,
             CommandAction::Remove(ptr_str) => process_remove_event_obj(obj, ptr_str, &ctx)?,
         }
     }
@@ -341,4 +344,15 @@ fn remove_all_pointers(obj: &mut Value, pointers: &[PointerBuf]) -> EmptyResult 
     }
 
     Ok(())
+}
+
+fn trim_event_objects(objs: Value) -> Value {
+    Value::Array(
+        objs.as_array()
+            .unwrap() // it is an error to pass a non-array to this function
+            .iter()
+            .filter(|o| !o.is_null())
+            .cloned()
+            .collect(),
+    )
 }

--- a/sk-cli/src/skel/mod.rs
+++ b/sk-cli/src/skel/mod.rs
@@ -8,9 +8,15 @@ use std::sync::mpsc;
 
 use pest::Parser;
 use pest_derive::Parser;
-use sk_store::ExportedTrace;
+use sk_store::{
+    ExportedTrace,
+    TraceEvent,
+};
 
-use self::ast::parse_command;
+use self::ast::{
+    Command,
+    parse_command,
+};
 use self::engine::process_event;
 
 pub mod metric_names {
@@ -23,6 +29,30 @@ pub mod metric_names {
 #[derive(Parser)]
 #[grammar = "src/skel/skel.pest"]
 struct SkelParser;
+
+pub fn process_trace(
+    trace: &ExportedTrace,
+    commands: &Vec<Command>,
+    update_channel: Option<mpsc::Sender<()>>,
+) -> anyhow::Result<Vec<TraceEvent>> {
+    let mut new_events = Vec::with_capacity(trace.events.len());
+    for (evt, _) in trace.iter() {
+        let mut new_event = evt.clone();
+        for cmd in commands {
+            new_event = process_event(cmd, new_event)?;
+        }
+
+        // Only add the event if it actually does anything
+        if !new_event.applied_objs.is_empty() || !new_event.deleted_objs.is_empty() {
+            new_events.push(new_event);
+        }
+        if let Some(ref c) = update_channel {
+            let _ = c.send(()); // if we can't send on the channel, nbd
+        }
+    }
+
+    Ok(new_events)
+}
 
 pub async fn apply_skel_file(
     trace: &ExportedTrace,
@@ -39,16 +69,7 @@ pub async fn apply_skel_file(
         })
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
-    let mut new_events = Vec::with_capacity(trace.events.len());
-    for (evt, _) in trace.iter() {
-        let mut new_event = evt.clone();
-        for cmd in &parsed_commands {
-            new_event = process_event(cmd, new_event)?;
-        }
-        new_events.push(new_event);
-        let _ = update_channel.send(()); // if we can't send on the channel, nbd
-    }
-
+    let new_events = process_trace(trace, &parsed_commands, Some(update_channel))?;
     let new_trace = ExportedTrace {
         version: trace.version,
         config: trace.config.clone(),

--- a/sk-cli/src/skel/skel.pest
+++ b/sk-cli/src/skel/skel.pest
@@ -118,14 +118,14 @@ trace_selector_expr = _{ trace_selector_all | trace_selector_list }
 //  - modify(trace_selector, operation): performs an operation to every matching item in the trace
 //  - remove(trace_selector, resource_path): removes a field from every matching item in the trace
 
-command = _{  modify_cmd | /* delete_func | insert_func | */ remove_cmd }
+command = _{  modify_cmd | delete_cmd | /* insert_func | */ remove_cmd }
 
 assignment = { resource_path  ~ "=" ~ (val | resource_path) }
 modify_args = _{ trace_selector_expr ~ "," ~ assignment | assignment }
 modify_cmd = { "modify" ~ "(" ~ modify_args ~ ")" }
 
-// delete_args = _{ trace_selector_expr }
-// delete_func = { "delete" ~ "(" ~ delete_args ~ ")" }
+delete_args = _{ trace_selector_expr }
+delete_cmd = { "delete" ~ "(" ~ delete_args ~ ")" }
 
 // insert_args = _{ ts_val ~ "," ~ resource }
 // insert_func = { "insert" ~ "(" ~ insert_args ~ ")" }

--- a/sk-cli/src/skel/tests/ast_test.rs
+++ b/sk-cli/src/skel/tests/ast_test.rs
@@ -15,6 +15,7 @@ use crate::skel::ast::{
     TestOperation,
     TraceSelector,
     VarDef,
+    parse_delete_command,
     parse_modify_command,
     parse_remove_command,
     parse_resource_conditional,
@@ -25,10 +26,24 @@ use crate::skel::ast::{
 };
 
 #[rstest]
+fn test_parse_delete_command() {
+    let expected = Command {
+        trace_selector: TraceSelector::All,
+        action: CommandAction::Delete,
+    };
+    let cmd = SkelParser::parse(Rule::command, "delete(*)")
+        .unwrap()
+        .next()
+        .unwrap()
+        .into_inner();
+    assert_ok_eq_x!(&parse_delete_command(cmd, 1234), &expected);
+}
+
+#[rstest]
 fn test_parse_modify_command() {
     let expected = Command {
         trace_selector: TraceSelector::All,
-        action: CommandAction::Apply("/metadata/labels/asdf".into(), Rhs::Value(json!("foo"))),
+        action: CommandAction::Modify("/metadata/labels/asdf".into(), Rhs::Value(json!("foo"))),
     };
     let cmd = SkelParser::parse(Rule::command, "modify(metadata.labels.asdf = \"foo\")")
         .unwrap()

--- a/sk-cli/src/skel/tests/engine_test.rs
+++ b/sk-cli/src/skel/tests/engine_test.rs
@@ -4,13 +4,17 @@ use blackbox_metrics::{
     MetricsRead,
 };
 use json_patch_ext::PointerBuf;
+use kube::api::DynamicObject;
 use serde_json::{
     Value,
     json,
 };
+use sk_store::TraceEvent;
 
 use super::*;
 use crate::skel::ast::{
+    Command,
+    CommandAction,
     Conditional,
     Rhs,
     TestOperation,
@@ -19,6 +23,7 @@ use crate::skel::ast::{
 };
 use crate::skel::context::*;
 use crate::skel::engine::{
+    process_event,
     process_modify_event_obj,
     process_remove_event_obj,
     reify_pointers,
@@ -64,6 +69,32 @@ fn ctx_with_x(mut ctx: MatchContext) -> MatchContext {
         ),
     );
     ctx
+}
+
+#[rstest]
+fn test_process_event_deleted_obj(test_deployment: DynamicObject) {
+    let mut evt = TraceEvent {
+        ts: 1234,
+        applied_objs: vec![test_deployment],
+        deleted_objs: vec![],
+    };
+    evt = process_event(
+        &Command {
+            action: CommandAction::Delete,
+            trace_selector: TraceSelector::All,
+        },
+        evt,
+    )
+    .unwrap();
+
+    assert_eq!(
+        evt,
+        TraceEvent {
+            ts: 1234,
+            applied_objs: vec![],
+            deleted_objs: vec![]
+        }
+    );
 }
 
 #[rstest]

--- a/sk-cli/src/skel/tests/itest.rs
+++ b/sk-cli/src/skel/tests/itest.rs
@@ -522,7 +522,56 @@ fn test_remove_command(#[case] cmd_str: &str, #[case] evt: TraceEvent, #[case] e
 }
 
 // We don't need to test all the same "match" selectors here, because most of these are covered by
-// the remove cases above.  Just add the ones that are specific to modify semantics.
+// the remove cases above.  Just add the ones that are specific to the individual command's
+// semantics.
+
+#[rstest]
+#[case::delete_all_event_objs(
+    "delete(*);",
+    vec![TraceEvent{
+        ts: 1234,
+        applied_objs: vec![DynamicObject{
+            types: None,
+            metadata: Default::default(),
+            data: json!({}),
+        }],
+        deleted_objs: vec![],
+    }],
+    vec![],
+)]
+#[case::delete_some_event_objs(
+    "delete(metadata.name == \"foo\");",
+    vec![TraceEvent{
+        ts: 1234,
+        applied_objs: vec![DynamicObject{
+            types: None,
+            metadata: metav1::ObjectMeta{ name: Some("foo".into()), ..Default::default()},
+            data: json!({}),
+        }, DynamicObject{
+            types: None,
+            metadata: metav1::ObjectMeta{ name: Some("bar".into()), ..Default::default()},
+            data: json!({}),
+        }],
+        deleted_objs: vec![],
+    }],
+    vec![TraceEvent{
+        ts: 1234,
+        applied_objs: vec![DynamicObject{
+            types: None,
+            metadata: metav1::ObjectMeta{ name: Some("bar".into()), ..Default::default()},
+            data: json!({}),
+        }],
+        deleted_objs: vec![],
+    }],
+)]
+fn test_delete_command(#[case] cmd_str: &str, #[case] evts: Vec<TraceEvent>, #[case] expected: Vec<TraceEvent>) {
+    let trace = ExportedTrace::new_with_events(evts);
+    let mut skel = SkelParser::parse(Rule::skel, &cmd_str).unwrap();
+    let cmd = parse_command(skel.next().unwrap(), 1234).unwrap();
+    let res = process_trace(&trace, &vec![cmd], None).unwrap();
+    assert_eq!(res, expected);
+}
+
 #[rstest]
 #[case::modify_implicit_match_star(
     "modify(spec.template.spec.nodeSelector.\"simkube.dev/foo\" = \"bar\");",

--- a/sk-cli/src/skel/tests/parser_test.rs
+++ b/sk-cli/src/skel/tests/parser_test.rs
@@ -35,6 +35,7 @@ use super::*;
     "modify(@t >= 10m && spec.template.spec.nodeSelector.\"simkube.dev/foo\" == \"bar\",
       spec.template.spec.nodeSelector.\"simkube.dev/foo\" = \"baz\");"
 )]
+#[case("delete(@t >= 10m && spec.template.spec.nodeSelector.\"simkube.dev/foo\" == \"bar\");")]
 fn test_skel_should_parse(#[case] command: &str) {
     assert_ok!(SkelParser::parse(Rule::skel, command));
 }


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- Added the `delete` keyword to SKEL to support removing objects wholesale from a trace (e.g., Jobs that are already in a "completed" state at the start of the trace)
- There were a couple spots where I missed a rename from `Apply` to `Modify` in #227, so I fixed those.

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- Updated the unit and integration tests
- Manual testing on trace files
- ~I don't think there are any tests that cover the "if the TraceEvent is empty, remove the entire event" logic, which I kindof would like to have tested, but also that function is not nice to test.~  I've factored that function out to make it easier to test, because we're going to want to have access to that logic down the line anyways.

- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
