### PR TITLE
SK-230: fix: drop nodeName field for tracked pod objects

### DIFF
--- a/sk-core/src/k8s/tests/util_test.rs
+++ b/sk-core/src/k8s/tests/util_test.rs
@@ -1,6 +1,9 @@
 use assertables::*;
 use clockabilly::Utc;
-use serde_json as json;
+use serde_json::{
+    Value,
+    json,
+};
 
 use super::*;
 
@@ -29,10 +32,10 @@ fn test_sanitize_obj() {
             ..Default::default()
         },
         types: None,
-        data: json::Value::Null,
+        data: Value::Null,
     };
 
-    sanitize_obj(&mut obj, "bar.blah.sh/v2", "Stuff");
+    sanitize_obj(&GVK::new("bar.blah.sh", "v2", "Stuff"), &mut obj);
 
     assert_some!(obj.metadata.owner_references);
 
@@ -49,6 +52,28 @@ fn test_sanitize_obj() {
         obj.types
             .is_some_and(|tm| tm.api_version == "bar.blah.sh/v2" && tm.kind == "Stuff")
     );
+}
+
+#[rstest]
+fn test_sanitize_pod_obj() {
+    let mut obj = DynamicObject {
+        metadata: metav1::ObjectMeta {
+            name: Some("test-obj".into()),
+            namespace: Some(TEST_NAMESPACE.into()),
+
+            ..Default::default()
+        },
+        types: None,
+        data: json!({
+            "spec": {
+                "nodeName": "ip-1-2-3-4.internal",
+            }
+        }),
+    };
+
+    sanitize_obj(&*POD_GVK, &mut obj);
+
+    assert!(!dyn_obj_spec(&obj).unwrap().contains_key("nodeName"));
 }
 
 fn build_label_sel(key: &str, op: &str, value: Option<&str>) -> metav1::LabelSelector {

--- a/sk-core/src/k8s/util.rs
+++ b/sk-core/src/k8s/util.rs
@@ -1,7 +1,10 @@
 use std::collections::BTreeMap;
 
 use kube::api::Resource;
-use serde_json as json;
+use serde_json::{
+    Map,
+    Value,
+};
 
 use super::*;
 use crate::errors::*;
@@ -43,7 +46,7 @@ pub fn build_deletable(gvk: &GVK, ns_name: &str) -> DynamicObject {
             ..Default::default()
         },
         types: Some(gvk.into_type_meta()),
-        data: json::Value::Null,
+        data: Value::Null,
     }
 }
 
@@ -72,6 +75,18 @@ where
     build_object_meta_helper(Some(namespace.into()), name, sim_name, owner)
 }
 
+pub fn dyn_obj_spec(obj: &DynamicObject) -> Option<&Map<String, Value>> {
+    obj.data
+        .as_object()
+        .and_then(|data| data.get("spec").and_then(|spec| spec.as_object()))
+}
+
+pub fn dyn_obj_spec_mut(obj: &mut DynamicObject) -> Option<&mut Map<String, Value>> {
+    obj.data
+        .as_object_mut()
+        .and_then(|data| data.get_mut("spec").and_then(|spec| spec.as_object_mut()))
+}
+
 pub fn dyn_obj_type_str(obj: &DynamicObject) -> String {
     obj.types
         .as_ref()
@@ -83,7 +98,7 @@ pub fn format_gvk_name(gvk: &GVK, ns_name: &str) -> String {
     format!("{gvk}:{ns_name}")
 }
 
-pub fn sanitize_obj(obj: &mut DynamicObject, api_version: &str, kind: &str) {
+pub fn sanitize_obj(gvk: &GVK, obj: &mut DynamicObject) {
     // N.B. We do not sanitize owner references here, since we need them
     // to compute owner chains in the TraceStore
     obj.metadata.creation_timestamp = None;
@@ -94,12 +109,16 @@ pub fn sanitize_obj(obj: &mut DynamicObject, api_version: &str, kind: &str) {
     obj.metadata.resource_version = None;
     obj.metadata.uid = None;
 
-    if let Some(a) = obj.metadata.annotations.as_mut() {
-        a.remove(LAST_APPLIED_CONFIG_LABEL_KEY);
-        a.remove(DEPL_REVISION_LABEL_KEY);
-    }
+    obj.annotations_mut().remove(LAST_APPLIED_CONFIG_LABEL_KEY);
+    obj.annotations_mut().remove(DEPL_REVISION_LABEL_KEY);
 
-    obj.types = Some(TypeMeta { api_version: api_version.into(), kind: kind.into() });
+    // If we are tracking pod objects (whether bare or not!), we want to ignore the node it was
+    // assigned to "in production" since this will certainly not exist in the simulation.
+    dyn_obj_spec_mut(obj).map(|spec| spec.remove("nodeName"));
+
+    // I don't quite remember what this is for, but I vaguely recall that for "deleted" resources
+    // it may not fill out the TypeMeta, so we set it here.
+    obj.types = Some(gvk.into_type_meta());
 }
 
 pub fn split_namespaced_name(name: &str) -> (String, String) {

--- a/sk-store/src/watchers/dyn_obj_watcher.rs
+++ b/sk-store/src/watchers/dyn_obj_watcher.rs
@@ -36,18 +36,18 @@ pub async fn new_with_stream(
     dyn_obj_tx: Sender,
     ready_tx: mpsc::Sender<bool>,
 ) -> anyhow::Result<ObjWatcher<DynamicObject>> {
-    // TODO if this fails (e.g., because some custom resource isn't present in the cluster)
-    // it will prevent the tracer from starting up
-    let api_version = gvk.api_version().clone();
-    let kind = gvk.kind.clone();
+    // TODO if this function fails (e.g., because some requested custom resource isn't present in
+    // the cluster) it will prevent the tracer from starting up
+
+    // The GVK needs to be cloned ahead of time because it's moved into the stream
+    let stream_gvk = gvk.clone();
 
     // The "unnamespaced" api variant can list/watch in all namespaces
     let (api, _) = apiset.unnamespaced_api_by_gvk(gvk).await?;
 
     let dyn_obj_handler = Box::new(DynObjHandler { gvk: gvk.clone(), dyn_obj_tx });
     let dyn_obj_stream = watcher(api.clone(), Default::default())
-        // All these objects need to be cloned because they're moved into the stream here
-        .modify(move |obj| sanitize_obj(obj, &api_version, &kind))
+        .modify(move |obj| sanitize_obj(&stream_gvk, obj))
         .map_err(|e| e.into())
         .boxed();
 


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- Make `sanitize_obj` remove the `nodeName` field from watched pod objects; this gets called by `dyn_obj_watcher` _before_ it gets passed into the store, and then the store computes the hash of the pod spec to see if it changes (and it ignores, e.g., status updates) so this way if a pod goes from Pending to Scheduled, we won't record that in the trace.

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- added a new test, `make test` passes
- manual testing

## Other Notes
<!-- any other notes/comments/feedback/suggestions that will help your reviewers out -->
- I didn't add it here, but I'm wondering if we want some kind of itest with bare pods since they're so weird/different.

- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
