### PR TITLE
SK-226: fix: set bare pod metadata correctly

### DIFF
--- a/sk-core/src/config.rs
+++ b/sk-core/src/config.rs
@@ -209,7 +209,7 @@ trackedObjects:
     #[case::job_none_paths(("batch","v1","Job"), None, Expected::Ok(vec!["/spec/template"]))]
     #[case::replicaset_none_paths(("apps","v1","ReplicaSet"), None, Expected::Ok(vec!["/spec"]))]
     #[case::statefulset_none_paths(("apps","v1","StatefulSet"), None, Expected::Ok(vec!["/spec/template"]))]
-    #[case::statefulset_none_paths(("","v1","Pod"), None, Expected::Ok(vec!["/"]))]
+    #[case::pod_none_paths(("","v1","Pod"), None, Expected::Ok(vec![""]))]
 
     fn test_normalize(
         #[case] input_gvk: (&str, &str, &str),

--- a/sk-core/src/constants.rs
+++ b/sk-core/src/constants.rs
@@ -75,6 +75,6 @@ pub static GVK_POD_SPEC_TEMPLATE_PATHS: LazyLock<HashMap<GVK, Vec<&'static str>>
         (JOB_GVK.clone(), vec!["/spec/template"]),
         (REPLICASET_GVK.clone(), vec!["/spec"]),
         (STATEFULSET_GVK.clone(), vec!["/spec/template"]),
-        (POD_GVK.clone(), vec!["/"]),
+        (POD_GVK.clone(), vec![""]),
     ])
 });

--- a/sk-driver/src/mutation.rs
+++ b/sk-driver/src/mutation.rs
@@ -107,7 +107,8 @@ pub async fn mutate_pod(
     add_empty_labels_annotations(pod, &mut patches);
     if !pod.labels_contains_key(SIMULATION_LABEL_KEY) {
         info!("first time seeing pod, adding tracking annotations");
-        patches.push(add_operation(format_ptr!("/metadata/labels/{}", escape(SIMULATION_LABEL_KEY)), json!(ctx.name)));
+        patches
+            .push(add_operation(format_ptr!("/metadata/labels/{}", escape(SIMULATION_LABEL_KEY)), json!(ctx.sim_name)));
         add_node_selector_tolerations(pod, &mut patches)?;
         add_pod_hash_annotations(hash, seq, &mut patches);
     }

--- a/sk-driver/src/runner.rs
+++ b/sk-driver/src/runner.rs
@@ -58,7 +58,7 @@ pub fn build_virtual_ns(ctx: &DriverContext, root: &SimulationRoot, namespace: &
 }
 
 pub fn build_virtual_obj(
-    ctx: &DriverContext,
+    sim_name: &str,
     root: &SimulationRoot,
     original_ns: &str,
     virtual_ns: &str,
@@ -67,23 +67,31 @@ pub fn build_virtual_obj(
 ) -> anyhow::Result<DynamicObject> {
     let owner = root;
     let mut vobj = obj.clone();
-    add_common_metadata(&ctx.name, owner, &mut vobj.metadata);
+    add_common_metadata(sim_name, owner, &mut vobj.metadata);
     vobj.metadata.namespace = Some(virtual_ns.into());
     klabel_insert!(vobj, VIRTUAL_LABEL_KEY => "true");
     patch_ext(&mut vobj.data, remove_operation(format_ptr!("/status")))?;
 
     if let Some(pod_spec_template_paths) = maybe_pod_spec_template_paths {
         for pod_spec_template_path in pod_spec_template_paths {
-            patch_ext(
-                &mut vobj.data,
-                add_operation(
-                    format_ptr!(
-                        "{pod_spec_template_path}/metadata/annotations/{}",
-                        escape(ORIG_NAMESPACE_ANNOTATION_KEY)
+            if pod_spec_template_path.is_empty() {
+                // For anything that has an empty pod_spec_template_path (afaik the only thing this
+                // would be is bare pods), we need to modify the DynamicObject's metadata field
+                // instead of setting a value on vobj.data, otherwise we get serialization issues.
+                vobj.annotations_mut()
+                    .insert(ORIG_NAMESPACE_ANNOTATION_KEY.into(), original_ns.into());
+            } else {
+                patch_ext(
+                    &mut vobj.data,
+                    add_operation(
+                        format_ptr!(
+                            "{pod_spec_template_path}/metadata/annotations/{}",
+                            escape(ORIG_NAMESPACE_ANNOTATION_KEY)
+                        ),
+                        json!(original_ns),
                     ),
-                    json!(original_ns),
-                ),
-            )?;
+                )?;
+            }
 
             // This is semi-duplicated from the pod mutation webhook; we need to set the tolerations
             // and nodeSelectors _here_ so that, e.g., things like DaemonSets will schedule properly
@@ -198,7 +206,7 @@ pub(crate) async fn run_trace_internal(
             }
 
             let pod_spec_template_path = ctx.trace.config.pod_spec_template_paths(&gvk);
-            let vobj = build_virtual_obj(ctx, &root, &original_ns, &virtual_ns, obj, pod_spec_template_path)?;
+            let vobj = build_virtual_obj(&ctx.sim_name, &root, &original_ns, &virtual_ns, obj, pod_spec_template_path)?;
 
             info!("applying {} {}", dyn_obj_type_str(&vobj), vobj.namespaced_name());
             apiset

--- a/sk-driver/src/tests/runner_test.rs
+++ b/sk-driver/src/tests/runner_test.rs
@@ -22,17 +22,13 @@ use crate::util::DRIVER_PAUSED_WAIT_SECONDS;
 // Must match the namespace in tests/data/trace.json
 const TEST_NS_NAME: &str = "default";
 
-#[rstest(tokio::test)]
-async fn test_build_virtual_object_multiple_pod_specs(test_sim_root: SimulationRoot, test_two_pods_obj: DynamicObject) {
-    let (_, client) = make_fake_apiserver();
-    let cache = OwnersCache::new(DynamicApiSet::new(client.clone()));
-    let ctx = build_driver_context(cache, ExportedTrace::default());
-
+#[rstest]
+fn test_build_virtual_object_multiple_pod_specs(test_sim_root: SimulationRoot, test_two_pods_obj: DynamicObject) {
     let pod_spec_template_paths = Some(vec!["/spec/template1".into(), "/spec/template2".into()]);
 
     let virtual_ns = format!("virtual-{TEST_NAMESPACE}");
     let vobj = build_virtual_obj(
-        &ctx,
+        TEST_SIM_NAME,
         &test_sim_root,
         TEST_NAMESPACE,
         &virtual_ns,
@@ -41,7 +37,7 @@ async fn test_build_virtual_object_multiple_pod_specs(test_sim_root: SimulationR
     )
     .unwrap();
 
-    assert_eq!(vobj.metadata.namespace.unwrap(), virtual_ns);
+    assert_eq!(vobj.namespace().unwrap(), virtual_ns);
     assert_eq!(
         vobj.data,
         json!({
@@ -88,6 +84,40 @@ async fn test_build_virtual_object_multiple_pod_specs(test_sim_root: SimulationR
                         ],
                     },
                 },
+            }
+        })
+    );
+}
+
+#[rstest]
+fn test_build_virtual_object_bare_pod(test_sim_root: SimulationRoot, test_dynamic_pod: DynamicObject) {
+    let pod_spec_template_paths = Some(vec!["".into()]);
+
+    let virtual_ns = format!("virtual-{TEST_NAMESPACE}");
+    let vobj = build_virtual_obj(
+        TEST_SIM_NAME,
+        &test_sim_root,
+        TEST_NAMESPACE,
+        &virtual_ns,
+        &test_dynamic_pod,
+        pod_spec_template_paths.as_deref(),
+    )
+    .unwrap();
+
+    assert_eq!(vobj.namespace().unwrap(), virtual_ns);
+    assert_eq!(vobj.annotations().get(ORIG_NAMESPACE_ANNOTATION_KEY).unwrap(), TEST_NAMESPACE);
+    assert_eq!(
+        vobj.data,
+        json!({
+            "spec": {
+                // Ensure that if there is no nodeSelector/tolerations defined,
+                // they get created anyways
+                "nodeSelector": {"type": "virtual" },
+                "tolerations": [{
+                    "key": VIRTUAL_NODE_TOLERATION_KEY,
+                    "operator": "Exists",
+                    "effect": "NoSchedule",
+                }],
             }
         })
     );

--- a/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@false.snap
+++ b/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@false.snap
@@ -13,7 +13,7 @@ Object {
         },
         "labels": Object {
             "foo": String("bar"),
-            "simkube.io/simulation": String("sk-test-driver-12345"),
+            "simkube.io/simulation": String("test-sim"),
         },
         "name": String("the-pod"),
         "namespace": String("test-namespace"),

--- a/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@true.snap
+++ b/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@true.snap
@@ -14,7 +14,7 @@ Object {
         },
         "labels": Object {
             "foo": String("bar"),
-            "simkube.io/simulation": String("sk-test-driver-12345"),
+            "simkube.io/simulation": String("test-sim"),
             "simkube.kwok.io/stage-complete": String("true"),
         },
         "name": String("the-pod"),

--- a/testutils/src/pods.rs
+++ b/testutils/src/pods.rs
@@ -1,5 +1,7 @@
 use clockabilly::DateTime;
+use kube::api::DynamicObject;
 use rstest::fixture;
+use serde_json::json;
 use sk_core::macros::*;
 use sk_core::prelude::*;
 
@@ -19,6 +21,20 @@ pub fn test_pod(#[default(TEST_POD.into())] name: String) -> corev1::Pod {
         },
         spec: Some(corev1::PodSpec { ..Default::default() }),
         status: Some(corev1::PodStatus { ..Default::default() }),
+    }
+}
+
+#[fixture]
+pub fn test_dynamic_pod(#[default(TEST_POD.into())] name: String) -> DynamicObject {
+    DynamicObject {
+        types: Some(POD_GVK.into_type_meta()),
+        metadata: metav1::ObjectMeta {
+            labels: klabel!("foo" => "bar"),
+            namespace: Some(TEST_NAMESPACE.into()),
+            name: Some(name),
+            ..Default::default()
+        },
+        data: json!({}),
     }
 }
 


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- there was a bug in bare pod handling wrt podSpecTemplatePaths, this needed to be the empty string instead of "/"; also, if the podSpecTemplatePath is empty, we need to set the DynamicObject.metadata field directly instead of putting it in vobj.data, otherwise we get serialization issues.
- Found and fixed a bug where pods were getting labeled with simulation name = the name of the driver pod instead of the actual name of the simulation
  - turns out this was broken in the mutating webhook, too!!! :rage: 

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- make test passes
  - fixed a test related to the bare pod template spec paths
  - added a new test for build_virtual_obj for the bare pod case
  - cleaned up the build_virtual_obj tests to make them not async, because they _really_ don't need to be
- manual testing

- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
