### PR TITLE
fix: truncate long labels

### DIFF
--- a/sk-core/src/k8s/tests/util_test.rs
+++ b/sk-core/src/k8s/tests/util_test.rs
@@ -76,6 +76,21 @@ fn test_sanitize_pod_obj() {
     assert!(!dyn_obj_spec(&obj).unwrap().contains_key("nodeName"));
 }
 
+#[rstest]
+#[case::way_too_short("x", "x")]
+#[case::too_short("asdfasdfasdfasdf", "asdfasdfasdfasdf")]
+#[case::limit(
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)]
+#[case::too_long(
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbb",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaXXXX"
+)]
+fn test_truncate_label(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(truncate_label(input.into()), expected);
+}
+
 fn build_label_sel(key: &str, op: &str, value: Option<&str>) -> metav1::LabelSelector {
     metav1::LabelSelector {
         match_expressions: Some(vec![metav1::LabelSelectorRequirement {

--- a/sk-core/src/k8s/util.rs
+++ b/sk-core/src/k8s/util.rs
@@ -10,13 +10,18 @@ use super::*;
 use crate::errors::*;
 use crate::prelude::*;
 
+const MAX_LABEL_LENGTH: usize = 63;
+
 pub fn add_common_metadata<K>(sim_name: &str, owner: &K, meta: &mut metav1::ObjectMeta)
 where
     K: Resource<DynamicType = ()>,
 {
     let labels = &mut meta.labels.get_or_insert_default();
-    labels.insert(SIMULATION_LABEL_KEY.into(), sim_name.into());
-    labels.insert(APP_KUBERNETES_IO_NAME_KEY.into(), meta.name.clone().unwrap());
+    labels.insert(SIMULATION_LABEL_KEY.into(), truncate_label(sim_name.into()));
+    labels.insert(
+        APP_KUBERNETES_IO_NAME_KEY.into(),
+        truncate_label(meta.name.clone().unwrap()), // everything should have a name (???)
+    );
 
     meta.owner_references.get_or_insert_default().push(metav1::OwnerReference {
         api_version: K::api_version(&()).into(),
@@ -126,6 +131,14 @@ pub fn split_namespaced_name(name: &str) -> (String, String) {
         Some((namespace, name)) => (namespace.into(), name.into()),
         None => ("".into(), name.into()),
     }
+}
+
+pub fn truncate_label(mut value: String) -> String {
+    if value.len() > MAX_LABEL_LENGTH {
+        value.truncate(MAX_LABEL_LENGTH - 4);
+        value.push_str("XXXX");
+    }
+    value
 }
 
 impl<T: Resource> KubeResourceExt for T {

--- a/sk-core/src/macros.rs
+++ b/sk-core/src/macros.rs
@@ -4,14 +4,14 @@ pub use std::collections::BTreeMap;
 #[macro_export]
 macro_rules! klabel {
     ($($key:expr=>$val:expr),+$(,)?) => {
-        Some(BTreeMap::from([$(($key.to_string(), $val.to_string())),+]))
+        Some(BTreeMap::from([$(($key.to_string(), $crate::k8s::truncate_label($val.to_string()))),+]))
     };
 }
 
 #[macro_export]
 macro_rules! klabel_insert {
     ($obj:ident, $($key:tt=>$val:tt),+$(,)?) => {
-        $($obj.labels_mut().insert($key.to_string(), $val.to_string()));+
+        $($obj.labels_mut().insert($key.to_string(), $crate::k8s::truncate_label($val.to_string())));+
     };
 }
 


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- k8s labels can be a maximum of 63 characters long, in some places we were trying to set a label that is longer than that based on production data (specifically, if the name of the simulated resource is longer than 63 characters, we can run into this); apply the truncate_label function anywhere we set a label.

## How
<!-- if the changes are not obvious/straightforward, explain how you approached the problem -->
- updated the klabel and klabel_insert macros so this gets auto-applied (query: is this going to bite us at some point in the future because it's too magic?  only time will tell)
- the add_common_metadata function can't use those macros because they depend on a kube::Resource object, instead of just the metadata object.  Maybe it could be refactored, but I wasn't interested in doing that today.

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- make test passes; new tests added
- manual testing

- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
