### PR TITLE
SK-251 // Don't panic on failed delete

### DIFF
--- a/sk-driver/src/runner.rs
+++ b/sk-driver/src/runner.rs
@@ -221,11 +221,14 @@ pub(crate) async fn run_trace_internal(
             let virtual_ns = format!("{}-{}", ctx.virtual_ns_prefix, obj.namespace().unwrap());
             let mut vobj = obj.clone();
             vobj.metadata.namespace = Some(virtual_ns);
-            apiset
+            if let Err(e) = apiset
                 .api_for_obj(&vobj)
                 .await?
                 .delete(&obj.name_any(), &Default::default())
-                .await?;
+                .await
+            {
+                tracing::warn!("delete failed, continuing: {:?}", e)
+            };
         }
 
         if let Some(next_ts) = maybe_next_ts {

--- a/sk-driver/src/runner.rs
+++ b/sk-driver/src/runner.rs
@@ -221,14 +221,14 @@ pub(crate) async fn run_trace_internal(
             let virtual_ns = format!("{}-{}", ctx.virtual_ns_prefix, obj.namespace().unwrap());
             let mut vobj = obj.clone();
             vobj.metadata.namespace = Some(virtual_ns);
-            if let Err(e) = apiset
-                .api_for_obj(&vobj)
-                .await?
-                .delete(&obj.name_any(), &Default::default())
-                .await
-            {
-                tracing::warn!("delete failed, continuing: {:?}", e)
-            };
+            let api = apiset.api_for_obj(&vobj).await?;
+            match api.delete(&obj.name_any(), &Default::default()).await {
+                Ok(_) => {},
+                Err(kube::Error::Api(e)) if e.code == 404 => {
+                    warn!("delete failed, continuing: {:?}", e);
+                },
+                Err(e) => return Err(e.into()),
+            }
         }
 
         if let Some(next_ts) = maybe_next_ts {

--- a/sk-driver/src/tests/runner_test.rs
+++ b/sk-driver/src/tests/runner_test.rs
@@ -195,9 +195,10 @@ mod itest {
     use super::*;
 
     #[rstest(tokio::test)]
-    #[case::has_start_marker(true)]
-    #[case::no_start_marker(false)]
-    async fn test_driver_run(test_sim: Simulation, #[case] has_start_marker: bool) {
+    #[case::has_start_marker(true, true)]
+    #[case::no_start_marker(false, true)]
+    #[case::start_marker_obj_not_found(true, false)]
+    async fn test_driver_run(test_sim: Simulation, #[case] has_start_marker: bool, #[case] delete_obj_exists: bool) {
         let (mut fake_apiserver, client) = make_fake_apiserver();
         let cache = OwnersCache::new(DynamicApiSet::new(client.clone()));
 
@@ -255,11 +256,12 @@ mod itest {
                 .path(format!("/apis/simkube.io/v1/simulations/{TEST_SIM_NAME}"));
             then.json_body_obj(&test_sim_clone);
         });
-        fake_apiserver.handle(|when, then| {
+        let delete_status = if delete_obj_exists { status_ok() } else { status_not_found() };
+        fake_apiserver.handle(move |when, then| {
             when.method(DELETE).path(format!(
                 "/apis/apps/v1/namespaces/{TEST_VIRT_NS_PREFIX}-{TEST_NS_NAME}/deployments/nginx-deployment-2"
             ));
-            then.json_body(status_ok());
+            then.json_body(delete_status.clone());
         });
         fake_apiserver.handle(|when, then| {
             when.path(format!("/apis/simkube.io/v1/simulationroots/{TEST_DRIVER_ROOT_NAME}"))

--- a/sk-driver/src/tests/runner_test.rs
+++ b/sk-driver/src/tests/runner_test.rs
@@ -197,7 +197,7 @@ mod itest {
     #[rstest(tokio::test)]
     #[case::has_start_marker(true, true)]
     #[case::no_start_marker(false, true)]
-    #[case::start_marker_obj_not_found(true, false)]
+    #[case::delete_obj_not_found(true, false)]
     async fn test_driver_run(test_sim: Simulation, #[case] has_start_marker: bool, #[case] delete_obj_exists: bool) {
         let (mut fake_apiserver, client) = make_fake_apiserver();
         let cache = OwnersCache::new(DynamicApiSet::new(client.clone()));


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- driver currently panics if a delete fails for any reason causing the simulation to fail
- most frequently this is caused by an edited trace file (SKEL)

## How
<!-- if the changes are not obvious/straightforward, explain how you approached the problem -->
- instead of propagating any error from the delete request to the kube API we just log it
- all other errors will propagate like usual

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- This was instructive to test it took me a little while to reproduce, the easiest way to to create a trace with some basic applys and deletes in a sample cluster then use SKEL to delete the apply for one of the resources causing a delete without a created object within the trace. That is sufficient to reliably recreate the error

### Previously the driver fails when the delete request returns a 404, crashing the driver:
<img width="1799" height="82" alt="Screenshot 2026-05-21 at 8 39 30 PM" src="https://github.com/user-attachments/assets/0850f9c9-8065-443c-8a7c-3f9ee41a9c6b" />

### After the error handling change we just see a warning in the driver pod log:
<img width="1340" height="100" alt="Screenshot 2026-05-21 at 8 25 02 PM" src="https://github.com/user-attachments/assets/0db2d83e-d95b-4dcd-a5a6-18f7fa3ccdde" />


## Other Notes
<!-- any other notes/comments/feedback/suggestions that will help your reviewers out -->
- if we want to make it even more specific we could only suppress the 404 erros instead of all errors returned by delete() but that doesn't seem necessary.

- [ X ] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
