### PR TITLE
SK-252 // fix: pod lifecycles for bare pods

### DIFF
--- a/sk-core/src/k8s/pod_lifecycle.rs
+++ b/sk-core/src/k8s/pod_lifecycle.rs
@@ -105,6 +105,15 @@ impl PodLifecycleData {
         }
     }
 
+    pub fn bound_start_ts(mut self, min_start_ts: i64) -> Self {
+        match self {
+            PodLifecycleData::Empty => (),
+            PodLifecycleData::Running(ref mut ts) => *ts = max(*ts, min_start_ts),
+            PodLifecycleData::Finished(ref mut ts, _) => *ts = max(*ts, min_start_ts),
+        }
+        self
+    }
+
     pub fn empty(&self) -> bool {
         self == PodLifecycleData::Empty
     }

--- a/sk-core/src/k8s/tests/owners_test.rs
+++ b/sk-core/src/k8s/tests/owners_test.rs
@@ -1,41 +1,33 @@
 use std::collections::HashMap;
 
 use assertables::*;
-use k8s_openapi::Metadata;
 use serde_json::json;
 
 use super::*;
 
 #[fixture]
-fn rsref() -> metav1::OwnerReference {
-    metav1::OwnerReference {
-        api_version: "apps/v1".into(),
-        kind: "ReplicaSet".into(),
-        name: TEST_REPLICASET.into(),
-        uid: "asdfasdf".into(),
-        ..Default::default()
-    }
-}
-
-#[fixture]
-fn deplref() -> metav1::OwnerReference {
-    metav1::OwnerReference {
-        api_version: "apps/v1".into(),
-        kind: "Deployment".into(),
-        name: TEST_DEPLOYMENT.into(),
+fn test_shell_pod(mut test_pod: corev1::Pod) -> corev1::Pod {
+    // overwrite the defaults in test_pod
+    test_pod.metadata.owner_references = Some(vec![metav1::OwnerReference {
+        api_version: "tortoise/v1".into(),
+        kind: "Shell".into(),
+        name: "the-tortoise-shell".into(),
         uid: "yuioyoiuy".into(),
         ..Default::default()
-    }
+    }]);
+
+    test_pod
 }
 
 #[rstest(tokio::test)]
 async fn test_compute_owners_for_cached(
     mut test_pod: corev1::Pod,
-    rsref: metav1::OwnerReference,
-    deplref: metav1::OwnerReference,
+    rs_owner_ref: metav1::OwnerReference,
+    depl_owner_ref: metav1::OwnerReference,
 ) {
-    test_pod.owner_references_mut().push(rsref.clone());
-    let expected_owners = vec![rsref, deplref];
+    // overwrite the defaults in test_pod
+    test_pod.metadata.owner_references = Some(vec![rs_owner_ref.clone()]);
+    let expected_owners = vec![rs_owner_ref, depl_owner_ref];
 
     let (_, client) = make_fake_apiserver();
     let owners = HashMap::from([((corev1::Pod::gvk(), test_pod.namespaced_name()), expected_owners.clone())]);
@@ -48,8 +40,8 @@ async fn test_compute_owners_for_cached(
 #[rstest(tokio::test)]
 async fn test_compute_owners_for(
     mut test_pod: corev1::Pod,
-    rsref: metav1::OwnerReference,
-    deplref: metav1::OwnerReference,
+    rs_owner_ref: metav1::OwnerReference,
+    depl_owner_ref: metav1::OwnerReference,
 ) {
     let (mut fake_apiserver, client) = make_fake_apiserver();
     fake_apiserver.handle_multiple(2, |when, then| {
@@ -57,7 +49,7 @@ async fn test_compute_owners_for(
         then.json_body(apps_v1_discovery());
     });
 
-    let rs_owner = deplref.clone();
+    let rs_owner = depl_owner_ref.clone();
     fake_apiserver.handle(move |when, then| {
         when.path("/apis/apps/v1/replicasets");
         then.json_body(json!({
@@ -91,10 +83,11 @@ async fn test_compute_owners_for(
 
     let mut cache = OwnersCache::new(DynamicApiSet::new(client));
 
-    test_pod.owner_references_mut().push(rsref.clone());
+    // overwrite the defaults in test_pod
+    test_pod.metadata.owner_references = Some(vec![rs_owner_ref.clone()]);
     let res = cache.compute_owners_for(&corev1::Pod::gvk(), &test_pod).await;
 
-    assert_iter_eq!(res, vec![rsref, deplref]);
+    assert_iter_eq!(res, vec![rs_owner_ref, depl_owner_ref]);
     fake_apiserver.assert();
 }
 
@@ -102,7 +95,8 @@ async fn test_compute_owners_for(
 async fn test_compute_owners_for_bad_ref(mut test_pod: corev1::Pod) {
     let (fake_apiserver, client) = make_fake_apiserver();
 
-    test_pod.metadata_mut().owner_references = Some(vec![metav1::OwnerReference {
+    // overwrite the defaults in test_pod
+    test_pod.metadata.owner_references = Some(vec![metav1::OwnerReference {
         api_version: "tortoise/asdf/bar".into(),
         kind: "Shell".into(),
         name: "the-tortoise-shell".into(),
@@ -118,27 +112,18 @@ async fn test_compute_owners_for_bad_ref(mut test_pod: corev1::Pod) {
 }
 
 #[rstest(tokio::test)]
-async fn test_compute_owners_for_api_not_found(mut test_pod: corev1::Pod) {
+async fn test_compute_owners_for_api_not_found(test_shell_pod: corev1::Pod) {
     let (mut fake_apiserver, client) = make_fake_apiserver();
     fake_apiserver.handle_not_found("/apis/tortoise/v1".into());
-
-    test_pod.metadata_mut().owner_references = Some(vec![metav1::OwnerReference {
-        api_version: "tortoise/v1".into(),
-        kind: "Shell".into(),
-        name: "the-tortoise-shell".into(),
-        uid: "yuioyoiuy".into(),
-        ..Default::default()
-    }]);
-
     let mut cache = OwnersCache::new(DynamicApiSet::new(client));
-    let res = cache.compute_owners_for(&corev1::Pod::gvk(), &test_pod).await;
+    let res = cache.compute_owners_for(&corev1::Pod::gvk(), &test_shell_pod).await;
 
     assert_iter_eq!(res, vec![]);
     fake_apiserver.assert();
 }
 
 #[rstest(tokio::test)]
-async fn test_compute_owners_for_list_fails(mut test_pod: corev1::Pod) {
+async fn test_compute_owners_for_list_fails(test_shell_pod: corev1::Pod) {
     let (mut fake_apiserver, client) = make_fake_apiserver();
     fake_apiserver.handle(|when, then| {
         when.path("/apis/tortoise/v1");
@@ -161,23 +146,15 @@ async fn test_compute_owners_for_list_fails(mut test_pod: corev1::Pod) {
 
     fake_apiserver.handle_not_found("/apis/tortoise/v1/shells".into());
 
-    test_pod.metadata_mut().owner_references = Some(vec![metav1::OwnerReference {
-        api_version: "tortoise/v1".into(),
-        kind: "Shell".into(),
-        name: "the-tortoise-shell".into(),
-        uid: "yuioyoiuy".into(),
-        ..Default::default()
-    }]);
-
     let mut cache = OwnersCache::new(DynamicApiSet::new(client));
-    let res = cache.compute_owners_for(&corev1::Pod::gvk(), &test_pod).await;
+    let res = cache.compute_owners_for(&corev1::Pod::gvk(), &test_shell_pod).await;
 
     assert_iter_eq!(res, vec![]);
     fake_apiserver.assert();
 }
 
 #[rstest(tokio::test)]
-async fn test_compute_owners_for_too_many(mut test_pod: corev1::Pod) {
+async fn test_compute_owners_for_too_many(test_shell_pod: corev1::Pod) {
     let (mut fake_apiserver, client) = make_fake_apiserver();
     fake_apiserver.handle(|when, then| {
         when.path("/apis/tortoise/v1");
@@ -219,17 +196,8 @@ async fn test_compute_owners_for_too_many(mut test_pod: corev1::Pod) {
         }));
     });
 
-
-    test_pod.metadata_mut().owner_references = Some(vec![metav1::OwnerReference {
-        api_version: "tortoise/v1".into(),
-        kind: "Shell".into(),
-        name: "the-tortoise-shell".into(),
-        uid: "yuioyoiuy".into(),
-        ..Default::default()
-    }]);
-
     let mut cache = OwnersCache::new(DynamicApiSet::new(client));
-    let res = cache.compute_owners_for(&corev1::Pod::gvk(), &test_pod).await;
+    let res = cache.compute_owners_for(&corev1::Pod::gvk(), &test_shell_pod).await;
 
     assert_iter_eq!(res, vec![]);
     fake_apiserver.assert();

--- a/sk-core/src/k8s/tests/util_test.rs
+++ b/sk-core/src/k8s/tests/util_test.rs
@@ -1,5 +1,6 @@
 use assertables::*;
 use clockabilly::Utc;
+use kube::api::TypeMeta;
 use serde_json::{
     Value,
     json,
@@ -55,7 +56,9 @@ fn test_sanitize_obj() {
 }
 
 #[rstest]
-fn test_sanitize_pod_obj() {
+#[case::no_type(None)]
+#[case::some_type(Some(POD_GVK.into_type_meta()))]
+fn test_sanitize_pod_obj(#[case] types: Option<TypeMeta>) {
     let mut obj = DynamicObject {
         metadata: metav1::ObjectMeta {
             name: Some("test-obj".into()),
@@ -63,7 +66,7 @@ fn test_sanitize_pod_obj() {
 
             ..Default::default()
         },
-        types: None,
+        types,
         data: json!({
             "spec": {
                 "nodeName": "ip-1-2-3-4.internal",

--- a/sk-core/src/k8s/util.rs
+++ b/sk-core/src/k8s/util.rs
@@ -7,8 +7,8 @@ use serde_json::{
 };
 
 use super::*;
+use crate::constants::*;
 use crate::errors::*;
-use crate::prelude::*;
 
 const MAX_LABEL_LENGTH: usize = 63;
 
@@ -104,6 +104,19 @@ pub fn format_gvk_name(gvk: &GVK, ns_name: &str) -> String {
 }
 
 pub fn sanitize_obj(gvk: &GVK, obj: &mut DynamicObject) {
+    // Kubernetes does not always fill out the TypeMeta (possibly for deleted resources, but I'm
+    // pretty sure definitely for the results of a List API call -- you know, like when you run
+    // ListAndWatch to start a new informer).  I _believe_ the type information for the list call only
+    // gets populated on the outer wrapper of the list and not for individual objects in the list.
+    //
+    // There are a couple related GitHub issues here:
+    //   - https://github.com/kubernetes-sigs/controller-runtime/issues/1517
+    //   - https://github.com/kubernetes-sigs/controller-runtime/issues/1735
+    //
+    // ANYWAYS as a result of this extremely annoying behaviour, we fill in the type meta here,
+    // which we know as a part of setting up the informer.
+    obj.types = Some(gvk.into_type_meta());
+
     // N.B. We do not sanitize owner references here, since we need them
     // to compute owner chains in the TraceStore
     obj.metadata.creation_timestamp = None;
@@ -119,11 +132,9 @@ pub fn sanitize_obj(gvk: &GVK, obj: &mut DynamicObject) {
 
     // If we are tracking pod objects (whether bare or not!), we want to ignore the node it was
     // assigned to "in production" since this will certainly not exist in the simulation.
-    dyn_obj_spec_mut(obj).map(|spec| spec.remove("nodeName"));
-
-    // I don't quite remember what this is for, but I vaguely recall that for "deleted" resources
-    // it may not fill out the TypeMeta, so we set it here.
-    obj.types = Some(gvk.into_type_meta());
+    if gvk == &*POD_GVK {
+        dyn_obj_spec_mut(obj).map(|spec| spec.remove("nodeName"));
+    }
 }
 
 pub fn split_namespaced_name(name: &str) -> (String, String) {

--- a/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@false.snap
+++ b/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@false.snap
@@ -17,6 +17,14 @@ Object {
         },
         "name": String("the-pod"),
         "namespace": String("test-namespace"),
+        "ownerReferences": Array [
+            Object {
+                "apiVersion": String("apps/v1"),
+                "kind": String("Deployment"),
+                "name": String("the-deployment"),
+                "uid": String("yuioyoiuy"),
+            },
+        ],
     },
     "spec": Object {
         "containers": Array [],

--- a/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@true.snap
+++ b/sk-driver/src/tests/snapshots/sk_driver__tests__mutation_test__itest__mutate_pod@true.snap
@@ -19,6 +19,14 @@ Object {
         },
         "name": String("the-pod"),
         "namespace": String("test-namespace"),
+        "ownerReferences": Array [
+            Object {
+                "apiVersion": String("apps/v1"),
+                "kind": String("Deployment"),
+                "name": String("the-deployment"),
+                "uid": String("yuioyoiuy"),
+            },
+        ],
     },
     "spec": Object {
         "containers": Array [],

--- a/sk-store/src/pod_owners_map.rs
+++ b/sk-store/src/pod_owners_map.rs
@@ -64,6 +64,14 @@ impl PodOwnersMap {
         self.index.contains_key(ns_name)
     }
 
+    pub(crate) fn get_lifecycle_for(&self, ns_name: &str) -> Vec<PodLifecycleData> {
+        self.index.get(ns_name).map_or(vec![], |((gvk, owner_ns_name), hash, _len)| {
+            self.m
+                .get(&(gvk.clone(), owner_ns_name.clone()))
+                .map_or(vec![], |data| data.get(hash).cloned().unwrap_or_default())
+        })
+    }
+
     pub(crate) fn store_new_pod_lifecycle(
         &mut self,
         pod_ns_name: &str,
@@ -155,7 +163,22 @@ pub(crate) fn filter_lifecycles_map(
     let filtered_map: PodLifecyclesMap = lifecycles_map
         .iter()
         .filter_map(|(hash, lifecycles)| {
-            let new_lifecycles: Vec<_> = lifecycles.iter().filter(|l| l.overlaps(start_ts, end_ts)).cloned().collect();
+            let new_lifecycles: Vec<_> = lifecycles
+                .iter()
+                .cloned()
+                .filter_map(|l| {
+                    if l.overlaps(start_ts, end_ts) {
+                        // The timing for any lifecycle that _contains_ the start time of the trace
+                        // will get truncated; this is necessary for the "bare pods" scenario, and
+                        // in any other scenario it can either be correct or incorrect to do so.
+                        // For the ease of the code right now, I'm just unilaterally truncating the
+                        // time, but if we need to make it more rigorous later we can do so.
+                        Some(l.bound_start_ts(start_ts))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
             if new_lifecycles.is_empty() {
                 return None;
             }

--- a/sk-store/src/store.rs
+++ b/sk-store/src/store.rs
@@ -118,7 +118,7 @@ impl TraceStore {
                     continue;
                 }
 
-                if evt.ts < start_ts {
+                if evt.ts < start_ts && !self.obj_is_finished_pod(obj, start_ts)? {
                     flattened_objects.insert(ns_name.clone(), obj.clone());
                 } else {
                     filtered_applied_objs.push(obj.clone());
@@ -215,12 +215,27 @@ impl TraceStore {
         if self.pod_owners.has_pod(ns_name) {
             self.pod_owners.update_pod_lifecycle(ns_name, lifecycle_data)?;
         } else if let Some(pod) = maybe_pod {
-            let owners = self
-                .owners_cache
-                .lock()
-                .await
-                .lookup_by_name_or_obj(&corev1::Pod::gvk(), ns_name, maybe_pod.as_ref())
-                .await;
+            // TODO (SK-254) we may still want to do this if the pod is owned but we are choosing
+            // to not track the owner for whatever reason
+            let owners = if pod.owner_references().is_empty() {
+                // If we have a bare pod, then we make the pod its own owner, which is a
+                // little weird and not, like, technically correct, but will work fine for our
+                // purposes; the bare pods are tracked in the index, so this will pass all the
+                // checks below.
+                vec![metav1::OwnerReference {
+                    api_version: "v1".into(),
+                    kind: POD_GVK.kind.clone(),
+                    name: pod.name_any(),
+                    ..Default::default()
+                }]
+            } else {
+                // If it's not a bare pod, then we look up the owners in the cache.
+                self.owners_cache
+                    .lock()
+                    .await
+                    .lookup_by_name_or_obj(&corev1::Pod::gvk(), ns_name, maybe_pod.as_ref())
+                    .await
+            };
 
             for owner in owners {
                 // Pods are guaranteed to have namespaces, so the unwrap is fine
@@ -288,7 +303,23 @@ impl TraceStore {
         }
         Ok(false)
     }
+
+    fn obj_is_finished_pod(&self, obj: &DynamicObject, start_ts: i64) -> anyhow::Result<bool> {
+        Ok(
+            if GVK::from_dynamic_obj(obj)? == *POD_GVK
+                && let lifecycles = self.pod_owners.get_lifecycle_for(&obj.namespaced_name())
+                // if it's a bare pod, there "should" only be one recorded lifecycle
+                && let Some(PodLifecycleData::Finished(_, finish)) = lifecycles.first()
+                && *finish < start_ts
+            {
+                true
+            } else {
+                false
+            },
+        )
+    }
 }
+
 
 fn object_matches_filter(obj: &DynamicObject, f: &ExportFilters) -> bool {
     obj.metadata

--- a/sk-store/src/tests/pod_owners_map_test.rs
+++ b/sk-store/src/tests/pod_owners_map_test.rs
@@ -95,7 +95,7 @@ fn test_filter_lifecycles_map() {
             // These overlap
             PodLifecycleData::Running(6),
             PodLifecycleData::Finished(7, 9),
-            PodLifecycleData::Finished(1, 8),
+            PodLifecycleData::Finished(1, 8), // This one will get truncated
             PodLifecycleData::Finished(5, 10),
             // These don't
             PodLifecycleData::Running(10),
@@ -103,7 +103,14 @@ fn test_filter_lifecycles_map() {
             PodLifecycleData::Finished(1, 2),
         ],
     )]);
-    let expected_map = PodLifecyclesMap::from([(1234, lifecycles_map[&1234][0..4].into())]);
+    let expected_map = PodLifecyclesMap::from([(
+        1234,
+        lifecycles_map[&1234][0..4]
+            .iter()
+            .cloned()
+            .map(|l| l.bound_start_ts(5))
+            .collect(),
+    )]);
     let res = filter_lifecycles_map(START_TS, END_TS, &lifecycles_map).unwrap();
     assert_eq!(res, expected_map);
 }

--- a/sk-store/src/tests/trace_store_test.rs
+++ b/sk-store/src/tests/trace_store_test.rs
@@ -38,11 +38,7 @@ fn tracer() -> TraceStore {
         TracerConfig {
             tracked_objects: HashMap::from([(
                 DEPLOYMENT_GVK.clone(),
-                TrackedObjectConfig {
-                    track_lifecycle: true,
-                    pod_spec_template_paths: Some(vec!["/spec/template".into()]),
-                    ..Default::default()
-                },
+                TrackedObjectConfig { track_lifecycle: true, ..Default::default() },
             )]),
         },
         apiset,
@@ -86,6 +82,95 @@ async fn test_collect_events_filtered(mut tracer: TraceStore) {
     // Always an empty event at the beginning
     assert_eq!(events, vec![TraceEvent { ts: 1, ..Default::default() }]);
     assert_is_empty!(index);
+}
+
+#[rstest(tokio::test)]
+async fn test_collect_events_finished_pod(mut tracer: TraceStore) {
+    let pod1 = test_dynamic_pod("finished-before-start".into());
+    let pod1_ns_name = format!("{TEST_NAMESPACE}/finished-before-start");
+    let pod2 = test_dynamic_pod("running-before-start".into());
+    let pod2_ns_name = format!("{TEST_NAMESPACE}/running-before-start");
+    let pod3 = test_dynamic_pod("finished-after-start".into());
+    let pod3_ns_name = format!("{TEST_NAMESPACE}/finished-after-start");
+    let pod4 = test_dynamic_pod("running-after-start".into());
+    let pod4_ns_name = format!("{TEST_NAMESPACE}/running-after-start");
+    tracer.events = vec![
+        // This pod gets filtered
+        TraceEvent {
+            ts: 1,
+            applied_objs: vec![pod1],
+            deleted_objs: vec![],
+        },
+        // These three pods don't
+        TraceEvent {
+            ts: 2,
+            applied_objs: vec![pod2.clone()],
+            deleted_objs: vec![],
+        },
+        TraceEvent {
+            ts: 5,
+            applied_objs: vec![pod3.clone()],
+            deleted_objs: vec![],
+        },
+        TraceEvent {
+            ts: 7,
+            applied_objs: vec![pod4.clone()],
+            deleted_objs: vec![],
+        },
+    ];
+
+    tracer.pod_owners.store_new_pod_lifecycle(
+        &pod1_ns_name,
+        &*POD_GVK,
+        &pod1_ns_name,
+        1234,
+        &PodLifecycleData::Finished(1, 2),
+    );
+    tracer.pod_owners.store_new_pod_lifecycle(
+        &pod2_ns_name,
+        &*POD_GVK,
+        &pod2_ns_name,
+        1234,
+        &PodLifecycleData::Running(1),
+    );
+    tracer.pod_owners.store_new_pod_lifecycle(
+        &pod3_ns_name,
+        &*POD_GVK,
+        &pod3_ns_name,
+        1234,
+        &PodLifecycleData::Finished(5, 6),
+    );
+    tracer.pod_owners.store_new_pod_lifecycle(
+        &pod4_ns_name,
+        &*POD_GVK,
+        &pod4_ns_name,
+        1234,
+        &PodLifecycleData::Running(7),
+    );
+
+    let (events, _) = tracer.collect_events(3, 10, &Default::default(), false).await.unwrap();
+
+    // Always an empty event at the beginning
+    assert_eq!(
+        events,
+        vec![
+            TraceEvent {
+                ts: 3,
+                applied_objs: vec![pod2.clone()],
+                deleted_objs: vec![]
+            },
+            TraceEvent {
+                ts: 5,
+                applied_objs: vec![pod3.clone()],
+                deleted_objs: vec![]
+            },
+            TraceEvent {
+                ts: 7,
+                applied_objs: vec![pod4.clone()],
+                deleted_objs: vec![]
+            },
+        ]
+    );
 }
 
 #[rstest(tokio::test)]
@@ -267,7 +352,7 @@ async fn test_record_pod_lifecycle_already_stored_no_pod(mut tracer: TraceStore)
     expected_lifecycle_data[pod_seq_idx] = new_lifecycle_data.clone();
 
     let pod_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_POD);
-    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_REPLICASET);
+    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_DEPLOYMENT);
     tracer.pod_owners =
         mock_pod_owners_map(&pod_ns_name, EMPTY_POD_SPEC_HASH, &owner_ns_name, init_lifecycle_data, pod_seq_idx);
     tracer
@@ -286,7 +371,7 @@ async fn test_record_pod_lifecycle_already_stored_no_pod(mut tracer: TraceStore)
 #[rstest(tokio::test)]
 async fn test_record_pod_lifecycle_with_new_pod_no_tracked_owner(mut tracer: TraceStore, test_pod: corev1::Pod) {
     let ns_name = test_pod.namespaced_name();
-    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_REPLICASET);
+    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_DEPLOYMENT);
     let new_lifecycle_data = PodLifecycleData::Finished(5, 45);
     tracer
         .record_pod_lifecycle(&ns_name, &Some(test_pod), &new_lifecycle_data.clone())
@@ -306,14 +391,12 @@ async fn test_record_pod_lifecycle_with_new_pod_no_tracked_owner(mut tracer: Tra
 #[case::dont_track_lifecycle(false)]
 async fn test_record_pod_lifecycle_with_new_pod_hash(
     mut tracer: TraceStore,
-    mut test_pod: corev1::Pod,
-    owner_ref: metav1::OwnerReference,
+    test_pod: corev1::Pod,
     #[case] track_lifecycle: bool,
 ) {
     let ns_name = test_pod.namespaced_name();
-    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, owner_ref.name);
+    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_DEPLOYMENT);
     let new_lifecycle_data = PodLifecycleData::Finished(5, 45);
-    test_pod.owner_references_mut().push(owner_ref);
 
     tracer.config.tracked_objects.get_mut(&*DEPLOYMENT_GVK).unwrap().track_lifecycle = track_lifecycle;
     tracer
@@ -335,19 +418,14 @@ async fn test_record_pod_lifecycle_with_new_pod_hash(
 }
 
 #[rstest(tokio::test)]
-async fn test_record_pod_lifecycle_with_new_pod_existing_hash(
-    mut tracer: TraceStore,
-    mut test_pod: corev1::Pod,
-    owner_ref: metav1::OwnerReference,
-) {
+async fn test_record_pod_lifecycle_with_new_pod_existing_hash(mut tracer: TraceStore, test_pod: corev1::Pod) {
     let new_lifecycle_data = PodLifecycleData::Finished(5, 45);
     let init_lifecycle_data = vec![PodLifecycleData::Running(5)];
     let mut expected_lifecycle_data = init_lifecycle_data.clone();
     expected_lifecycle_data.push(new_lifecycle_data.clone());
 
     let pod_ns_name = test_pod.namespaced_name();
-    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, owner_ref.name);
-    test_pod.owner_references_mut().push(owner_ref);
+    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_DEPLOYMENT);
 
     tracer
         .index
@@ -380,7 +458,7 @@ async fn test_record_pod_lifecycle_with_existing_pod(mut tracer: TraceStore, tes
     let expected_lifecycle_data = vec![new_lifecycle_data.clone()];
 
     let pod_ns_name = test_pod.namespaced_name();
-    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_REPLICASET);
+    let owner_ns_name = format!("{}/{}", TEST_NAMESPACE, TEST_DEPLOYMENT);
 
     tracer
         .index
@@ -396,6 +474,38 @@ async fn test_record_pod_lifecycle_with_existing_pod(mut tracer: TraceStore, tes
         tracer
             .pod_owners
             .lifecycle_data_for(&DEPLOYMENT_GVK, &owner_ns_name, EMPTY_POD_SPEC_HASH),
+        &expected_lifecycle_data,
+    );
+}
+
+// All we're really testing here is that using the pod as its own owner gets through this
+// logic successfully, we assume the other tests cover all the remaining cases
+#[rstest(tokio::test)]
+async fn test_record_bare_pod_lifecycle(mut tracer: TraceStore, mut test_pod: corev1::Pod) {
+    let new_lifecycle_data = PodLifecycleData::Finished(5, 45);
+    let expected_lifecycle_data = vec![new_lifecycle_data.clone()];
+
+    test_pod.metadata.owner_references = None;
+    let pod_ns_name = test_pod.namespaced_name();
+
+    // Configure bare pod tracking
+    tracer.index.insert(POD_GVK.clone(), pod_ns_name.clone(), 1);
+    tracer.config = TracerConfig {
+        tracked_objects: HashMap::from([(
+            POD_GVK.clone(),
+            TrackedObjectConfig { track_lifecycle: true, ..Default::default() },
+        )]),
+    };
+
+    tracer
+        .record_pod_lifecycle(&pod_ns_name, &Some(test_pod), &new_lifecycle_data)
+        .await
+        .unwrap();
+
+    assert_some_eq_x!(
+        tracer
+            .pod_owners
+            .lifecycle_data_for(&POD_GVK, &pod_ns_name, EMPTY_POD_SPEC_HASH),
         &expected_lifecycle_data,
     );
 }

--- a/sk-store/src/watchers/pod_watcher.rs
+++ b/sk-store/src/watchers/pod_watcher.rs
@@ -32,7 +32,7 @@ pub fn new_with_stream(
     ready_tx: mpsc::Sender<bool>,
 ) -> anyhow::Result<ObjWatcher<corev1::Pod>> {
     let pod_api: kube::Api<corev1::Pod> = kube::Api::all(client);
-    let pod_handler = Box::new(PodHandler { owned_pods: HashMap::new(), pod_tx });
+    let pod_handler = Box::new(PodHandler { tracked_pods: HashMap::new(), pod_tx });
     let pod_stream = watcher(pod_api, Default::default()).map_err(|e| e.into()).boxed();
     Ok(ObjWatcher::new(pod_handler, pod_stream, ready_tx))
 }
@@ -47,18 +47,18 @@ pub fn new_with_stream(
 // lifecycle data (currently start time and end time) have changed.  If so we forward that info
 // on to the store.
 pub(super) struct PodHandler {
-    // We store the list of owned pods in memory here, and cache the ownership chain for each pod;
+    // We store the list of tracked pods in memory here, and cache the current lifecycle data here.
     // This is a simpler data structure than what the object store needs, to allow for easy lookup
     // by pod name.  (The object store needs to store a bunch of extra metadata about sequence
     // number and pod hash and so forth).
-    owned_pods: HashMap<String, PodLifecycleData>,
+    tracked_pods: HashMap<String, PodLifecycleData>,
     pod_tx: Sender,
 }
 
 impl PodHandler {
     async fn handle_pod_applied(&mut self, ns_name: &str, pod: corev1::Pod) -> EmptyResult {
         let new_lifecycle_data = PodLifecycleData::new_for(&pod)?;
-        let current_lifecycle_data = self.owned_pods.get(ns_name);
+        let current_lifecycle_data = self.tracked_pods.get(ns_name);
 
         // We only store data if the lifecycle data has changed; there is some magic happening in
         // the > operator here; see pod_lifecycle.rs for details, but in short, we only allow
@@ -67,7 +67,7 @@ impl PodHandler {
         // Note that we only store non-empty lifecycle data, which is enforced since
         // PodLifecycleData::Empty < everything.
         if new_lifecycle_data > current_lifecycle_data {
-            self.owned_pods.insert(ns_name.into(), new_lifecycle_data.clone());
+            self.tracked_pods.insert(ns_name.into(), new_lifecycle_data.clone());
             self.send_pod_lifecycle_data(ns_name, Some(pod), new_lifecycle_data).await?;
         } else if !new_lifecycle_data.empty() && new_lifecycle_data != current_lifecycle_data {
             warn!(
@@ -89,7 +89,7 @@ impl PodHandler {
         ts: i64,
     ) -> EmptyResult {
         // Always remove the pod from our tracker, regardless of what else happens
-        self.owned_pods.remove(ns_name);
+        self.tracked_pods.remove(ns_name);
 
         // If the current lifecycle data is finished, we know it's already been written to the
         // store so we don't store it a second time.
@@ -123,7 +123,7 @@ impl PodHandler {
 
 #[async_trait]
 impl EventHandler<corev1::Pod> for PodHandler {
-    // TODO test it's OK to leave extra things in the owned_pods index (if it's still there when
+    // TODO test it's OK to leave extra things in the tracked_pods index (if it's still there when
     // we're done with all this
     async fn applied(&mut self, pod: corev1::Pod, _ts: i64) -> EmptyResult {
         let ns_name = pod.namespaced_name();
@@ -131,7 +131,7 @@ impl EventHandler<corev1::Pod> for PodHandler {
     }
 
     async fn deleted(&mut self, ns_name: &str, ts: i64) -> EmptyResult {
-        let Some(current_lifecycle_data) = self.owned_pods.get(ns_name) else {
+        let Some(current_lifecycle_data) = self.tracked_pods.get(ns_name) else {
             warn!("pod {ns_name} deleted but not tracked, may have already been processed");
             return Ok(());
         };
@@ -142,11 +142,11 @@ impl EventHandler<corev1::Pod> for PodHandler {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 impl PodHandler {
-    pub(crate) fn new_from_parts(owned_pods: HashMap<String, PodLifecycleData>, pod_tx: Sender) -> PodHandler {
-        PodHandler { owned_pods, pod_tx }
+    pub(crate) fn new_from_parts(tracked_pods: HashMap<String, PodLifecycleData>, pod_tx: Sender) -> PodHandler {
+        PodHandler { tracked_pods, pod_tx }
     }
 
     pub(crate) fn get_owned_pod_lifecycle(&self, ns_name: &str) -> Option<&PodLifecycleData> {
-        self.owned_pods.get(ns_name)
+        self.tracked_pods.get(ns_name)
     }
 }

--- a/testutils/src/pods.rs
+++ b/testutils/src/pods.rs
@@ -11,12 +11,36 @@ const CONTAINER_PREFIX: &str = "container";
 const INIT_CONTAINER_PREFIX: &str = "init-container";
 
 #[fixture]
-pub fn test_pod(#[default(TEST_POD.into())] name: String) -> corev1::Pod {
+pub fn rs_owner_ref() -> metav1::OwnerReference {
+    metav1::OwnerReference {
+        api_version: "apps/v1".into(),
+        kind: "ReplicaSet".into(),
+        name: TEST_REPLICASET.into(),
+        uid: "asdfasdf".into(),
+        ..Default::default()
+    }
+}
+
+#[fixture]
+pub fn depl_owner_ref() -> metav1::OwnerReference {
+    metav1::OwnerReference {
+        api_version: "apps/v1".into(),
+        kind: "Deployment".into(),
+        name: TEST_DEPLOYMENT.into(),
+        uid: "yuioyoiuy".into(),
+        ..Default::default()
+    }
+}
+
+
+#[fixture]
+pub fn test_pod(#[default(TEST_POD.into())] name: String, depl_owner_ref: metav1::OwnerReference) -> corev1::Pod {
     corev1::Pod {
         metadata: metav1::ObjectMeta {
             labels: klabel!("foo" => "bar"),
             namespace: Some(TEST_NAMESPACE.into()),
             name: Some(name),
+            owner_references: Some(vec![depl_owner_ref]),
             ..Default::default()
         },
         spec: Some(corev1::PodSpec { ..Default::default() }),


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- When we run `collect_events`, we filter out any top-level (bare) pods that were in a "Finished" state before the start of the trace collection
- When we run `export`, the exported pod lifecycles map has any lifecycles that overlap the start timestamp of the exported trace truncated to start at the beginning of the export.  This ensures that bare pods that were halfway through their job when the trace collection started only run for the remainder of their time during the simulation.  For pods that are owned (e.g., created by a CronJob) it's sortof arguable what the correct behaviour is here.
- When a bare pod is inserted into the trace, it is stuffed into the trace's index as its own owner; that way, it will show up later on when we perform lifecycle lookups.
- Minor change: only remove `nodeName` in santize_obj if the object is a pod; I went back and forth on this change, I can't think of any other type of object that would have a `nodeName`, and it probably doesn't matter at all but I decided on the balance it's better to be explicit.

## How
<!-- if the changes are not obvious/straightforward, explain how you approached the problem -->
These code changes are relatively self-explanatory, but I think it's worth enumerating the other things I tried here: the first attempt at this was to keep the trace collection the same (aside from making the pod its own owner) and have the _driver_ do the filtering out.  This required the driver to know which items were "initial" items (e.g., at timestamp 0 in the trace) and which ones weren't.  Then it would have to do a bunch of timeshifting to compare the "original" timestamps in the trace to the "current" timestamps in the simulation to then be able to figure out how much time was left for the pod.  This was a bunch of fairly ugly code, and was really difficult to reason about, so I finally landed on "filtering them out at trace export time" as the easier/better solution.

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- existing tests pass, some new tests are added to specifically handle the bare pods cases
- manual testing
- I also added a test to check for `None` TypeMeta information in `sanitize_obj`; that function itself fills in the TypeMeta if it's missing, so "in theory" there shouldn't need to be any _other_ tests needed.

## Related documents
- https://app.notion.com/p/Pod-Lifecycle-Tracking-Bug-36d0ba9f5f9180bbbd51ca4a32d09228

## Other Notes
<!-- any other notes/comments/feedback/suggestions that will help your reviewers out -->
- renamed a variable in the pod_watcher to be slightly more accurate

- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
