### PR TITLE
SK-267 // fix: pod lifecycle annotations work for bare pods

### DIFF
--- a/sk-core/src/config.rs
+++ b/sk-core/src/config.rs
@@ -9,7 +9,7 @@ use serde::{
 use thiserror::Error;
 use tracing::*;
 
-use crate::constants::GVK_POD_SPEC_TEMPLATE_PATHS;
+use crate::constants::KNOWN_GVKS_METADATA;
 use crate::k8s::GVK;
 
 #[derive(Debug, Error)]
@@ -86,7 +86,7 @@ impl TracerConfig {
     pub fn normalize(mut self) -> Result<Self, ConfigError> {
         let mut normalized_objects = HashMap::new();
         for (gvk, mut obj) in self.tracked_objects {
-            let maybe_default = GVK_POD_SPEC_TEMPLATE_PATHS.get(&gvk).cloned();
+            let maybe_default = KNOWN_GVKS_METADATA.get(&gvk).cloned();
             let resolved_paths = match obj.pod_spec_template_paths {
                 // User provided paths
                 Some(paths) if !paths.is_empty() => {
@@ -202,7 +202,7 @@ trackedObjects:
     #[case::unknown_gvk_with_paths(("fake","v1","Resource"), Some(vec!["/foo/bar"]), Expected::Ok(vec!["/foo/bar"]))]
     #[case::unknown_gvk_with_empty_paths(("fake","v1","Resource"), Some(vec![]), Expected::MissingPath)]
     #[case::unknown_gvk_with_none_paths(("fake","v1","Resource"), None, Expected::MissingPath)]
-    // Test all supported defaults in sk-core::constants::GVK_POD_SPEC_TEMPLATE_PATHS
+    // Test all supported defaults in KNOWN_GVKS
     #[case::cronjob_none_paths(("batch","v1","CronJob"), None, Expected::Ok(vec!["/spec/jobTemplate/spec/template"]))]
     #[case::daemonset_none_paths(("apps","v1","DaemonSet"), None, Expected::Ok(vec!["/spec/template"]))]
     #[case::deployment_none_paths(("apps","v1","Deployment"), None, Expected::Ok(vec!["/spec/template"]))]

--- a/sk-core/src/constants.rs
+++ b/sk-core/src/constants.rs
@@ -18,10 +18,10 @@ pub const APP_KUBERNETES_IO_COMPONENT_KEY: &str = "app.kubernetes.io/component";
 // Common annotations and labels for SimKube
 pub const ORIG_NAMESPACE_ANNOTATION_KEY: &str = "simkube.io/original-namespace";
 pub const SIMULATION_LABEL_KEY: &str = "simkube.io/simulation";
-pub const VIRTUAL_LABEL_KEY: &str = "simkube.io/virtual";
+pub const SKIP_LOCAL_VOLUME_MOUNT_ANNOTATION_KEY: &str = "simkube.io/skip-local-volue-mount";
 pub const POD_SPEC_STABLE_HASH_KEY: &str = "simkube.io/pod-spec-stable-hash";
 pub const POD_SEQUENCE_NUMBER_KEY: &str = "simkube.io/pod-sequence-number";
-pub const SKIP_LOCAL_VOLUME_MOUNT_ANNOTATION_KEY: &str = "simkube.io/skip-local-volue-mount";
+pub const VIRTUAL_LABEL_KEY: &str = "simkube.io/virtual";
 
 // Lifecycle management labels and annotations
 pub const KWOK_STAGE_COMPLETE_KEY: &str = "simkube.kwok.io/stage-complete";
@@ -67,7 +67,7 @@ pub static STATEFULSET_GVK: LazyLock<GVK> = LazyLock::new(appsv1::StatefulSet::g
 pub static POD_GVK: LazyLock<GVK> = LazyLock::new(corev1::Pod::gvk);
 
 // Supported default podSpecTemplatePaths
-pub static GVK_POD_SPEC_TEMPLATE_PATHS: LazyLock<HashMap<GVK, Vec<&'static str>>> = LazyLock::new(|| {
+pub static KNOWN_GVKS_METADATA: LazyLock<HashMap<GVK, Vec<&'static str>>> = LazyLock::new(|| {
     HashMap::from([
         (CRONJOB_GVK.clone(), vec!["/spec/jobTemplate/spec/template"]),
         (DAEMONSET_GVK.clone(), vec!["/spec/template"]),

--- a/sk-core/src/k8s/util.rs
+++ b/sk-core/src/k8s/util.rs
@@ -80,6 +80,15 @@ where
     build_object_meta_helper(Some(namespace.into()), name, sim_name, owner)
 }
 
+pub fn build_pod_self_owner_reference(pod: &corev1::Pod) -> metav1::OwnerReference {
+    metav1::OwnerReference {
+        api_version: "v1".into(),
+        kind: POD_GVK.kind.clone(),
+        name: pod.name_any(),
+        ..Default::default()
+    }
+}
+
 pub fn dyn_obj_spec(obj: &DynamicObject) -> Option<&Map<String, Value>> {
     obj.data
         .as_object()

--- a/sk-ctrl/src/objects.rs
+++ b/sk-ctrl/src/objects.rs
@@ -147,7 +147,18 @@ pub(crate) fn build_mutating_webhook(
             rules: Some(vec![admissionv1::RuleWithOperations {
                 api_groups: Some(vec!["".into()]),
                 api_versions: Some(vec!["v1".into()]),
-                operations: Some(vec!["CREATE".into()]),
+                // In the CI runner/cert-manager postmortem, there is a bunch of ink spilled about
+                // how the webhook only needs to watch CREATE instead of both CREATE and UPDATE, and
+                // some dumb engineer made an early-on decision to watch both.  Well, ha, joke's on
+                // you, Mr. Blog Post Writer, actually that dumb engineer was correct and we do need
+                // both CREATE and UPDATE messages; specifically, when KWOK changes the phase from
+                // "Pending" to "Running", we need to get notified so that we can apply the
+                // lifecycle annotations correctly.  This will likely require a bit of defensive
+                // care in the mutation webhook handler.
+                //
+                // Blog post for reference:
+                // https://blog.appliedcomputing.io/p/postmortem-intermittent-failure-in?utm_source=publication-search
+                operations: Some(vec!["CREATE".into(), "UPDATE".into()]),
                 resources: Some(vec!["pods".into(), "pods/status".into()]),
                 scope: Some("Namespaced".into()),
             }]),

--- a/sk-driver/src/mutation.rs
+++ b/sk-driver/src/mutation.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::iter;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -8,6 +9,7 @@ use kube::core::admission::{
     AdmissionRequest,
     AdmissionResponse,
     AdmissionReview,
+    Operation as AdmissionOperation,
 };
 use rocket::serde::json::Json;
 use serde_json::{
@@ -19,6 +21,7 @@ use sk_core::k8s::{
     GVK,
     PodExt,
     PodLifecycleData,
+    build_pod_self_owner_reference,
 };
 use sk_core::prelude::*;
 use tracing::*;
@@ -59,7 +62,7 @@ pub async fn handler(
 
     let mut resp = AdmissionResponse::from(&req);
     if let Some(pod) = &req.object {
-        resp = mutate_pod(ctx, sim, resp, pod, mut_data, UtcClock::boxed())
+        resp = mutate_pod(ctx, sim, req.operation.clone(), resp, pod, mut_data, UtcClock::boxed())
             .await
             .unwrap_or_else(|err| {
                 error!("could not perform mutation, blocking pod object: {err:?}");
@@ -75,6 +78,9 @@ pub async fn handler(
 pub async fn mutate_pod(
     ctx: &DriverContext,
     sim: &Simulation,
+    // BE AWARE: this gets called on both CREATE and UPDATE events, which means
+    // this function should not change any read-only fields on UPDATE.
+    op: AdmissionOperation,
     resp: AdmissionResponse,
     // TODO when we get the pod object, the final name hasn't been filled in yet;
     // make sure this doesn't cause any problems
@@ -95,7 +101,11 @@ pub async fn mutate_pod(
 
     let hash = match pod.annotations().get(POD_SPEC_STABLE_HASH_KEY) {
         Some(hash_str) => hash_str.parse::<u64>()?,
-        None => jsonutils::hash(&serde_json::to_value(&pod.stable_spec()?)?),
+        None => {
+            let stable_spec = pod.stable_spec()?;
+            debug!("computing pod stable spec: {:?}", stable_spec);
+            jsonutils::hash(&serde_json::to_value(&stable_spec)?)
+        },
     };
     let seq = match pod.annotations().get(POD_SEQUENCE_NUMBER_KEY) {
         Some(seq_str) => seq_str.parse::<usize>()?,
@@ -105,13 +115,14 @@ pub async fn mutate_pod(
 
     let mut patches = vec![];
     add_empty_labels_annotations(pod, &mut patches);
-    if !pod.labels_contains_key(SIMULATION_LABEL_KEY) {
+    if op == AdmissionOperation::Create {
         info!("first time seeing pod, adding tracking annotations");
         patches
             .push(add_operation(format_ptr!("/metadata/labels/{}", escape(SIMULATION_LABEL_KEY)), json!(ctx.sim_name)));
         add_node_selector_tolerations(pod, &mut patches)?;
         add_pod_hash_annotations(hash, seq, &mut patches);
     }
+
     if matches!(pod.status.as_ref(), Some(corev1::PodStatus{phase: Some(phase), ..}) if phase == "Running")
         && !pod.labels_contains_key(KWOK_STAGE_COMPLETE_KEY)
     {
@@ -183,15 +194,18 @@ fn add_lifecycle_fields(
     clock: Box<dyn Clockable + Send>,
 ) -> EmptyResult {
     if let Some(orig_ns) = pod.annotations().get(ORIG_NAMESPACE_ANNOTATION_KEY) {
-        for owner in owners {
+        // To handle the "bare pod" case, we also look to see if the pod has been recorded as its
+        // own owner in the trace file
+        for owner in owners.iter().chain(iter::once(&build_pod_self_owner_reference(pod))) {
             let owner_gvk = GVK::from_owner_ref(owner)?;
             let owner_ns_name = format!("{}/{}", orig_ns, owner.name);
             if !ctx.trace.has_obj(&owner_gvk, &owner_ns_name) {
+                debug!("owner {owner_gvk}.{owner_ns_name} for {} not found in trace", pod.namespaced_name());
                 continue;
             }
             let lifecycle = ctx.trace.lookup_pod_lifecycle(&owner_gvk, &owner_ns_name, hash, seq);
             if let Some(patch) = to_completion_time_annotation(sim.speed(), &lifecycle, &*clock) {
-                info!("applying lifecycle annotations");
+                info!("applying lifecycle labels and annotations");
                 patches.push(add_operation(
                     format_ptr!("/metadata/labels/{}", escape(KWOK_STAGE_COMPLETE_KEY)),
                     json!("true"),

--- a/sk-driver/src/tests/mutation_test.rs
+++ b/sk-driver/src/tests/mutation_test.rs
@@ -129,9 +129,17 @@ async fn test_mutate_pod_not_owned_by_sim(
     let owner = metav1::OwnerReference { name: "foo".into(), ..Default::default() };
     let ctx = ctx(test_pod.clone(), vec![owner.clone()], ExportedTrace::default());
     test_pod.owner_references_mut().push(owner);
-    adm_resp = mutate_pod(&ctx, &test_sim, adm_resp, &test_pod, &MutationData::new(), MockUtcClock::boxed(0))
-        .await
-        .unwrap();
+    adm_resp = mutate_pod(
+        &ctx,
+        &test_sim,
+        Operation::Create,
+        adm_resp,
+        &test_pod,
+        &MutationData::new(),
+        MockUtcClock::boxed(0),
+    )
+    .await
+    .unwrap();
     assert_eq!(adm_resp.patch, None);
 }
 
@@ -188,8 +196,8 @@ mod itest {
 
     #[rstest(tokio::test)]
     // don't need the cross-product of these cases
-    #[case(true)]
-    #[case(false)]
+    #[case::running_with_node_selector(true)]
+    #[case::not_running_or_no_node_selector(false)]
     async fn test_mutate_pod(
         mut test_sim: Simulation,
         mut test_pod: corev1::Pod,
@@ -230,9 +238,17 @@ mod itest {
 
         let ctx = ctx(test_pod.clone(), vec![root.clone(), depl.clone()], trace);
 
-        adm_resp = mutate_pod(&ctx, &test_sim, adm_resp, &test_pod, &MutationData::new(), MockUtcClock::boxed(0))
-            .await
-            .unwrap();
+        adm_resp = mutate_pod(
+            &ctx,
+            &test_sim,
+            Operation::Create,
+            adm_resp,
+            &test_pod,
+            &MutationData::new(),
+            MockUtcClock::boxed(0),
+        )
+        .await
+        .unwrap();
         let mut json_pod = serde_json::to_value(&test_pod).unwrap();
         let pod_patch: Patch = serde_json::from_slice(&adm_resp.patch.unwrap()).unwrap();
         for p in pod_patch.0 {

--- a/sk-store/src/store.rs
+++ b/sk-store/src/store.rs
@@ -10,6 +10,7 @@ use sk_core::k8s::{
     OwnersCache,
     PodExt,
     PodLifecycleData,
+    build_pod_self_owner_reference,
     format_gvk_name,
 };
 use sk_core::prelude::*;
@@ -222,12 +223,7 @@ impl TraceStore {
                 // little weird and not, like, technically correct, but will work fine for our
                 // purposes; the bare pods are tracked in the index, so this will pass all the
                 // checks below.
-                vec![metav1::OwnerReference {
-                    api_version: "v1".into(),
-                    kind: POD_GVK.kind.clone(),
-                    name: pod.name_any(),
-                    ..Default::default()
-                }]
+                vec![build_pod_self_owner_reference(pod)]
             } else {
                 // If it's not a bare pod, then we look up the owners in the cache.
                 self.owners_cache
@@ -258,7 +254,9 @@ impl TraceStore {
                 // of data that are unique to each pod that won't materially impact the behaviour?
                 // This does occur for example with coredns's volume mounts.  We may need to filter
                 // more things out from this and/or allow users to specify what is filtered out.
-                let hash = jsonutils::hash(&serde_json::to_value(pod.stable_spec()?)?);
+                let stable_spec = pod.stable_spec()?;
+                debug!("computing pod stable spec: {:?}", stable_spec);
+                let hash = jsonutils::hash(&serde_json::to_value(stable_spec)?);
                 self.pod_owners
                     .store_new_pod_lifecycle(ns_name, &owner_gvk, &owner_ns_name, hash, lifecycle_data);
                 break;

--- a/sk-store/src/trace.rs
+++ b/sk-store/src/trace.rs
@@ -68,6 +68,7 @@ impl ExportedTrace {
 
     pub fn import(data: Vec<u8>, maybe_duration: Option<&String>) -> anyhow::Result<ExportedTrace> {
         let mut exported_trace = rmp_serde::from_slice::<ExportedTrace>(&data).map_err(TraceError::ParseFailed)?;
+        exported_trace.config = exported_trace.config.normalize()?;
 
         if exported_trace.version != CURRENT_TRACE_FORMAT_VERSION {
             bail!("unsupported trace version: {}", exported_trace.version);
@@ -104,10 +105,14 @@ impl ExportedTrace {
         pod_hash: u64,
         seq: usize,
     ) -> PodLifecycleData {
+        let should_check_hash = use_stable_hash_for_lifecycle(owner_gvk);
+        if !should_check_hash {
+            debug!("ignoring stable hash for object because it is a known GVK");
+        }
         let maybe_lifecycle_data = self
             .pod_lifecycles
             .get(&(owner_gvk.clone(), owner_ns_name.into()))
-            .and_then(|l| l.get(&pod_hash));
+            .and_then(|l| if should_check_hash { l.get(&pod_hash) } else { l.iter().next().map(|(_, v)| v) });
         match maybe_lifecycle_data {
             Some(data) => data[seq % data.len()].clone(),
             _ => PodLifecycleData::Empty,
@@ -174,6 +179,17 @@ impl ExportedTrace {
         Ok(rmp_serde::to_vec_named(self)?)
     }
 }
+
+fn use_stable_hash_for_lifecycle(owner_gvk: &GVK) -> bool {
+    // Any of the standard Kubernetes resources only have one type of pod that they monitor, so we
+    // can safely ignore the stable hash data for these.  Any custom resource types may or may not
+    // have multiple pods per resource; for right now we default to requiring the use of the stable
+    // hash value for these resources, but this is maybe not the ideal solution in the long run.
+    //
+    // See also: SK-270, SK-271
+    !KNOWN_GVKS_METADATA.contains_key(owner_gvk)
+}
+
 
 #[derive(Clone)]
 pub struct TraceIterator<'a> {


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- Fix the mutation webhook to apply pod lifecycle annotations to bare pods
- Fix the (broken) pod lifecycle annotations for non-bare pods

## How
<!-- if the changes are not obvious/straightforward, explain how you approached the problem -->
- There were a number of bugs preventing lifecycle events from applying to bare pods:
  1. The `stable_spec` hash computed by the mutation webhook has changed because of changes in #214; instead of trying to correct for this issue right now, I decided to just ignore the stable_spec hash for all "known" Kubernetes objects, and I think we should revisit the stable_spec design in the future.
  2. Pods were created by the driver runner already bearing the SIMULATION_LABEL_KEY, so we had to change that to something else in order for the proper patches to get applied (see below)
  3. In #251 we made the trace record bare pods as their own owners; however, the mutation webhook looks up the pod ownership chain and wasn't aware of this edge case
  4. If the config in the ExportedTrace doesn't contain the implicit `podSpecTemplatePath`, then nothing would call `normalize` on it to populate this value for "known" k8s resources.
- Reverted the change in the mutating webhook to ignore UPDATE events
  - no idea how this ever worked in the last 6 months, but it's clearly not working now and is clearly required -- KWOK issues an UPDATE to move the pod from "Pending" to "Running", and we only want to set the lifecycle annotation on UPDATE events
  - relatedly, previously we used the presence/absence of a label to determine when the mutation webhook has first seen an object, but I decided it was cleaner to just pass in the operation that we've seen (`Update` or `Create`), since we have access to that information in the request payload.

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- all tests pass
- manual testing:
  - I confirmed that the pods the cronjob.sktrace file in `examples/traces` now are correctly moving to the Succeeded stage after 30 seconds, as desired
  - For the bare pods case, I asked Claude to write me a small bash script to generate bare "sleep 30" pods every minute; I used this to collect a trace, then replayed that trace and observed the bare pods also moving to Succeeded after 30 seconds.  Pasting the script here for posterity:

```
#!/usr/bin/env bash
set -euo pipefail

NAMESPACE="${NAMESPACE:-testing}"
IMAGE="${IMAGE:-busybox:latest}"

while true; do
  POD_NAME="bare-pod-$(date +%s)"

  kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: ${POD_NAME}
  namespace: ${NAMESPACE}
spec:
  restartPolicy: Never
  containers:
    - name: sleeper
      image: ${IMAGE}
      command: ["sleep", "30"]
EOF

  echo "[$(date -u +%FT%TZ)] Created pod ${POD_NAME}"
  sleep 60
done
```

## Other Notes
<!-- any other notes/comments/feedback/suggestions that will help your reviewers out -->
- I renamed `GVK_POD_SPEC_TEMPLATE_PATHS` to `KNOWN_GVKS_METADATA`, because I wanted a way to distinguish between stuff SimKube knows about natively and other stuff.  Right now the only "metadata" is the podSpecTemplatePath, but it's conceivable that at some future point there will be other things we want to track there.  If we _really_ wanted to do this right, we'd make a struct with a field so it's a little more clear what we're referencing, but for right now I don't think I really care.
- Added a few more debug outputs that made this all a lot easier to troubleshoot.

## Related links
- https://blog.appliedcomputing.io/p/postmortem-intermittent-failure-in
- Also fixes https://linear.app/acrl/issue/SK-272/mwc-needs-to-allow-update-requests
- Reverts part of https://github.com/acrlabs/simkube/pull/207

- [x] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
