### PR TITLE
chore: bump simkube github action runner ami

### DIFF
--- a/.github/workflows/simkube_e2e.yml
+++ b/.github/workflows/simkube_e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup SimKube GitHub Action runner
         uses: acrlabs/simkube-ci-action/actions/launch-runner@f597bcc52b7bd9ae050dcfa5f3c273e4c69f3a88
         with:
-          ami-id: ami-03e5877b8398d4577  # TODO: make this dynamic / latest AMI
+          ami-id: ami-07fa6c7cae4b254bd  # TODO: make this dynamic / latest AMI
           instance-type: m6a.large
           aws-region: us-west-2
           subnet-id: subnet-0cd4625c825e73e61


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- The E2E test failed because it was using an old AMI
- fix: update the AMI to the last published image

## Testing

- CI
   - [failed run with old AMI](https://github.com/acrlabs/simkube/actions/runs/29055844636)
   - [passing run with new AMI](https://github.com/acrlabs/simkube/actions/runs/29057449957)

- [ X ] I certify that this PR does not contain any code that has been generated with GitHub Copilot or any other AI-based code generation tool, in accordance with this project's policies.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
